### PR TITLE
feat: add converter for PSADT 3.x commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Getting started
 
 Notes
 - Uses PSADT 4.1.x function names (e.g., `Start-ADTMsiProcess`, `Start-ADTProcess`, `Show-ADTInstallationPrompt`).
+- Includes a converter to translate common PSADT 3.8/3.10 commands to 4.1 syntax.
 - Initial scenarios cover MSI install/uninstall/repair, MSP patch, process (system/user), and the main UI dialogs (Welcome/Progress/Prompt/Restart).
 - This is designed to be easy to extend. See `psadt-helper/js/commands.js`.
 

--- a/js/commands.js
+++ b/js/commands.js
@@ -55,7 +55,47 @@ function joinPathArray(baseVar, listText) {
   return items.length ? `@(${items.join(', ')})` : '';
 }
 
+// Convert a PSADT 3.8/3.10 command to PSADT 4.1 syntax.
+// Performs simple token replacements for function and parameter names.
+function convertLegacyCommand(cmd) {
+  if (!cmd) return '';
+  let out = String(cmd);
+  const fnMap = [
+    ['Execute-MSI', 'Start-ADTMsiProcess'],
+    ['Execute-MSP', 'Start-ADTMspProcess'],
+    ['Execute-Process', 'Start-ADTProcess'],
+    ['Show-InstallationWelcome', 'Show-ADTInstallationWelcome'],
+    ['Show-InstallationPrompt', 'Show-ADTInstallationPrompt'],
+    ['Show-InstallationProgress', 'Show-ADTInstallationProgress'],
+    ['Show-InstallationRestartPrompt', 'Show-ADTInstallationRestartPrompt']
+  ];
+  fnMap.forEach(([oldName, newName]) => {
+    out = out.replace(new RegExp(`\\b${oldName}\\b`, 'gi'), newName);
+  });
+  const paramMap = [
+    ['-Path', '-FilePath'],
+    ['-Parameters', '-ArgumentList'],
+    ['-Transform', '-Transforms'],
+    ['-LogName', '-LogFileName'],
+    ['-CloseApps', '-CloseProcesses'],
+    ['-ProgressPercentage', '-StatusBarPercentage']
+  ];
+  paramMap.forEach(([oldName, newName]) => {
+    out = out.replace(new RegExp(`(?<![\\w-])${oldName}(?=\\s|$)`, 'gi'), newName);
+  });
+  return out;
+}
+
 const PSADT_SCENARIOS = [
+  {
+    id: 'convert-legacy',
+    name: 'Convert 3.x Command',
+    description: 'Convert a PSADT 3.8/3.10 command to PSADT 4.1 syntax.',
+    fields: [
+      { id: 'legacy', label: 'Legacy Command', type: 'textarea', required: true }
+    ],
+    build: (v) => convertLegacyCommand(v.legacy)
+  },
   // MSI operations via Start-ADTMsiProcess
   {
     id: 'msi-install',
@@ -353,8 +393,9 @@ const PSADT_SCENARIOS = [
 
 if (typeof window !== 'undefined') {
   window.PSADT_SCENARIOS = PSADT_SCENARIOS;
+  window.convertLegacyCommand = convertLegacyCommand;
 }
 
 if (typeof module !== 'undefined') {
-  module.exports = { PSADT_SCENARIOS };
+  module.exports = { PSADT_SCENARIOS, convertLegacyCommand };
 }

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -1,5 +1,5 @@
 const assert = require('assert');
-const { PSADT_SCENARIOS } = require('../js/commands.js');
+const { PSADT_SCENARIOS, convertLegacyCommand } = require('../js/commands.js');
 
 const msi = PSADT_SCENARIOS.find(s => s.id === 'msi-install');
 const cmd = msi.build({
@@ -13,6 +13,13 @@ const cmd = msi.build({
 assert.strictEqual(
   cmd,
   'Start-ADTMsiProcess -Action Install -FilePath "$adtSession.DirFiles\\app.msi" -ArgumentList \'/qn\''
+);
+
+const legacy = "Execute-MSI -Action Install -Path 'app.msi' -Parameters '/qn' -LogName 'app.log'";
+const converted = convertLegacyCommand(legacy);
+assert.strictEqual(
+  converted,
+  "Start-ADTMsiProcess -Action Install -FilePath 'app.msi' -ArgumentList '/qn' -LogFileName 'app.log'"
 );
 
 console.log('All tests passed.');


### PR DESCRIPTION
## Summary
- add `convertLegacyCommand` to translate PSADT 3.8/3.10 syntax to PSADT 4.1
- expose converter via new "Convert 3.x Command" scenario
- document converter and test coverage

## Testing
- `node test/commands.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c3fbbd2fe08324b198ff72de46b3de