### PR TITLE
Add drag-and-drop PSADT command builder

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,6 +62,13 @@
           </div>
           <div id="script-commands" aria-live="polite"></div>
         </div>
+        <div id="builder" class="card">
+          <div class="output-toolbar">
+            <span class="output-title">Command Builder</span>
+          </div>
+          <div id="command-boxes" class="cmd-boxes" aria-label="PSADT commands"></div>
+          <div id="editor-area" class="cmd-editor" contenteditable="true" aria-label="Custom script editor"></div>
+        </div>
         <div id="empty" class="empty">
           <p>Select a scenario to begin.</p>
         </div>
@@ -109,6 +116,7 @@
 
     <script src="js/commands.js"></script>
     <script src="js/main.js"></script>
-    
+    <script src="js/editor.js"></script>
+
   </body>
   </html>

--- a/js/editor.js
+++ b/js/editor.js
@@ -1,0 +1,42 @@
+// Custom command editor with drag-and-drop PSADT command boxes
+(() => {
+  const builderEl = document.getElementById('builder');
+  if (!builderEl) return;
+
+  const boxesEl = document.getElementById('command-boxes');
+  const editorEl = document.getElementById('editor-area');
+
+  // allow dropping into editor
+  editorEl.addEventListener('dragover', e => e.preventDefault());
+  editorEl.addEventListener('drop', e => {
+    e.preventDefault();
+    const text = e.dataTransfer.getData('text/plain');
+    if (text) {
+      // append command followed by newline
+      editorEl.textContent += (editorEl.textContent ? '\n' : '') + text;
+    }
+  });
+
+  // fetch list of PSADT commands and render draggable boxes
+  fetch('psadt/psadt-cmds.txt')
+    .then(r => r.text())
+    .then(txt => {
+      const cmds = txt.split(/\r?\n/).filter(Boolean);
+      cmds.forEach(cmd => {
+        const box = document.createElement('div');
+        box.className = 'cmd-box';
+        box.textContent = cmd;
+        box.draggable = true;
+        box.addEventListener('dragstart', e => {
+          e.dataTransfer.setData('text/plain', cmd);
+        });
+        boxesEl.appendChild(box);
+      });
+    })
+    .catch(err => {
+      const msg = document.createElement('div');
+      msg.textContent = 'Failed to load commands';
+      boxesEl.appendChild(msg);
+      console.error(err);
+    });
+})();

--- a/styles.css
+++ b/styles.css
@@ -89,6 +89,10 @@ body{
   .script-btn{border:1px solid var(--border);background:#ffffff;border-radius:6px;padding:2px 6px;cursor:pointer}
   .script-btn:hover{background:#F6F6FF}
 
+  .cmd-boxes{display:flex;flex-wrap:wrap;gap:6px;margin-bottom:8px}
+  .cmd-box{background:#ffffff;border:1px solid var(--border);border-radius:6px;padding:6px 8px;cursor:grab;font-size:12px}
+  .cmd-editor{min-height:80px;background:#ffffff;border:1px dashed var(--border);border-radius:10px;padding:12px;white-space:pre-wrap}
+
     .btn{display:inline-flex;align-items:center;gap:10px;background:#ffffff;color:var(--text);border:1px solid var(--border);border-radius:12px;padding:8px 12px;cursor:pointer;font-weight:600;letter-spacing:.2px;transition:background .2s ease,border-color .2s ease,transform .02s ease, box-shadow .2s ease}
 .btn:hover{background:#F6F6FF;border-color:#DAD8FF;box-shadow:0 6px 24px rgba(23,91,235,.08)}
 .btn:active{transform:translateY(1px)}


### PR DESCRIPTION
## Summary
- Add command builder card with draggable PSADT command boxes and drop editor
- Load command list dynamically from `psadt/psadt-cmds.txt`
- Style command boxes and editor area for drag-and-drop interaction

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4627af7c88324a98d4a9a70d8f336