### PR TITLE
feat: modernize command builder and add easter egg

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,6 +66,7 @@
           <div class="output-toolbar">
             <span class="output-title">Command Builder</span>
           </div>
+          <input type="search" id="command-search" class="cmd-search" placeholder="Search commands" aria-label="Search commands" />
           <div id="command-boxes" class="cmd-boxes" aria-label="PSADT commands"></div>
           <div id="editor-area" class="cmd-editor" contenteditable="true" aria-label="Custom script editor"></div>
         </div>

--- a/js/editor.js
+++ b/js/editor.js
@@ -1,42 +1,67 @@
-// Custom command editor with drag-and-drop PSADT command boxes
+// Modern command editor with filtering and click-to-add
 (() => {
   const builderEl = document.getElementById('builder');
   if (!builderEl) return;
 
   const boxesEl = document.getElementById('command-boxes');
   const editorEl = document.getElementById('editor-area');
+  const searchEl = document.getElementById('command-search');
 
-  // allow dropping into editor
+  // Insert command text into editor
+  function insertCommand(cmd){
+    const current = editorEl.textContent;
+    editorEl.textContent = current ? `${current}\n${cmd}` : cmd;
+  }
+
+  // Allow dropping commands
   editorEl.addEventListener('dragover', e => e.preventDefault());
   editorEl.addEventListener('drop', e => {
     e.preventDefault();
     const text = e.dataTransfer.getData('text/plain');
-    if (text) {
-      // append command followed by newline
-      editorEl.textContent += (editorEl.textContent ? '\n' : '') + text;
-    }
+    if (text) insertCommand(text);
   });
 
-  // fetch list of PSADT commands and render draggable boxes
-  fetch('psadt/psadt-cmds.txt')
-    .then(r => r.text())
-    .then(txt => {
-      const cmds = txt.split(/\r?\n/).filter(Boolean);
-      cmds.forEach(cmd => {
-        const box = document.createElement('div');
-        box.className = 'cmd-box';
-        box.textContent = cmd;
-        box.draggable = true;
-        box.addEventListener('dragstart', e => {
-          e.dataTransfer.setData('text/plain', cmd);
-        });
-        boxesEl.appendChild(box);
+  // Render command boxes
+  function render(list){
+    boxesEl.innerHTML = '';
+    list.forEach(cmd => {
+      const box = document.createElement('div');
+      box.className = 'cmd-box';
+      box.textContent = cmd;
+      box.draggable = true;
+      box.tabIndex = 0;
+      box.setAttribute('role','button');
+      box.addEventListener('dragstart', e => e.dataTransfer.setData('text/plain', cmd));
+      box.addEventListener('click', () => insertCommand(cmd));
+      box.addEventListener('keydown', e => {
+        if (e.key === 'Enter') { e.preventDefault(); insertCommand(cmd); }
       });
-    })
-    .catch(err => {
+      boxesEl.appendChild(box);
+    });
+  }
+
+  // Load commands and set up filtering
+  async function init(){
+    try {
+      const res = await fetch('psadt/psadt-cmds.txt');
+      const txt = await res.text();
+      const cmds = txt.split(/\r?\n/).map(s => s.trim()).filter(Boolean);
+      render(cmds);
+      if (searchEl){
+        searchEl.addEventListener('input', () => {
+          const term = searchEl.value.trim().toLowerCase();
+          const filtered = cmds.filter(c => c.toLowerCase().includes(term));
+          render(filtered);
+        });
+      }
+    } catch (err){
       const msg = document.createElement('div');
       msg.textContent = 'Failed to load commands';
       boxesEl.appendChild(msg);
       console.error(err);
-    });
+    }
+  }
+
+  init();
 })();
+

--- a/js/main.js
+++ b/js/main.js
@@ -418,4 +418,16 @@
   if (bgSwatchesEl){ bgSwatchesEl.addEventListener('click', (e)=>{
     const btn = e.target.closest('.swatch'); if (!btn) return; const c = btn.getAttribute('data-color'); setBackground(c);
   }); }
+
+  // Hidden gimmick: classic Konami code reveals a surprise
+  const secret = ['ArrowUp','ArrowUp','ArrowDown','ArrowDown','ArrowLeft','ArrowRight','ArrowLeft','ArrowRight','b','a'];
+  const buffer = [];
+  window.addEventListener('keydown', (e) => {
+    buffer.push(e.key);
+    if (buffer.length > secret.length) buffer.shift();
+    if (secret.every((k,i) => k.toLowerCase() === (buffer[i] || '').toLowerCase())){
+      alert('🍕 You found the hidden pizza!');
+      buffer.length = 0;
+    }
+  });
 })();

--- a/styles.css
+++ b/styles.css
@@ -89,6 +89,7 @@ body{
   .script-btn{border:1px solid var(--border);background:#ffffff;border-radius:6px;padding:2px 6px;cursor:pointer}
   .script-btn:hover{background:#F6F6FF}
 
+  .cmd-search{width:100%;padding:6px 8px;border:1px solid var(--border);border-radius:8px;margin-bottom:8px}
   .cmd-boxes{display:flex;flex-wrap:wrap;gap:6px;margin-bottom:8px}
   .cmd-box{background:#ffffff;border:1px solid var(--border);border-radius:6px;padding:6px 8px;cursor:grab;font-size:12px}
   .cmd-editor{min-height:80px;background:#ffffff;border:1px dashed var(--border);border-radius:10px;padding:12px;white-space:pre-wrap}


### PR DESCRIPTION
## Summary
- add searchable command builder with click-to-add commands
- style builder search field
- hide a playful easter egg triggered by the Konami code

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c463c381388324a5be13ba4e498b9d