### PR TITLE
feat: allow custom legacy parameter mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Getting started
 Notes
 - Uses PSADT 4.1.x function names (e.g., `Start-ADTMsiProcess`, `Start-ADTProcess`, `Show-ADTInstallationPrompt`).
 - Includes a converter to translate common PSADT 3.8/3.10 commands to 4.1 syntax.
+- The legacy converter now supports custom parameter mappings for additional 3.x parameters.
 - Scenarios now include presets for common silent switches, file copy and registry helpers, in addition to MSI and dialog helpers.
 - Search the scenario list, validate GUID fields, and manage a script queue with reordering/removal.
 - Scripts can be shared via a generated link, downloaded, or copied to the clipboard.

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -54,4 +54,13 @@ assert.strictEqual(
   "Copy-ADTFile -Path \"$adtSession.DirFiles\\a.txt\" -Destination 'C\\Temp' -Overwrite"
 );
 
+// Custom mapping for legacy conversion
+const withExtra = convertLegacyCommand('Execute-Process -Path test.exe -Foo 1', [
+  ['-Foo', '-Bar']
+]);
+assert.strictEqual(
+  withExtra,
+  'Start-ADTProcess -FilePath test.exe -Bar 1'
+);
+
 console.log('All tests passed.');


### PR DESCRIPTION
## Summary
- allow users to supply extra parameter mappings when converting legacy PSADT commands
- expose custom mapping textarea in the "Convert 3.x Command" scenario
- document and test new behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c465467354832492432d6b0d41d0f2