### PR TITLE
feat: add scenario permalink and reset controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This installs dependencies, runs JS tests and Pester tests.
 - `tests/js` - Jest tests for JS helpers
 - `tests/ps` - Pester tests
 - `reports` - audit reports
+- `docs/usage.md` - feature usage guide
 
 ## Architecture
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,7 @@
+# Usage
+
+## Permalink & Reset
+
+When a scenario is filled out, use **Permalink** to copy a URL that captures the current selections. Share this link to load the same scenario and values.
+
+Use **Reset** to clear the current scenario and start over.

--- a/index.html
+++ b/index.html
@@ -49,6 +49,8 @@
             <div style="display:flex;gap:8px">
               <button id="add-btn" class="btn"><svg class="icon"><use href="#ic-play"/></svg><span>Add</span></button>
               <button id="copy-btn" class="btn"><svg class="icon"><use href="#ic-copy"/></svg><span>Copy</span></button>
+              <button id="share-btn" class="btn"><svg class="icon"><use href="#ic-copy"/></svg><span>Permalink</span></button>
+              <button id="reset-btn" class="btn"><span>Reset</span></button>
             </div>
           </div>
           <pre id="command" class="code" aria-live="polite"></pre>
@@ -119,6 +121,7 @@
 
     <script src="src/js/telemetry.js"></script>
     <script src="src/js/commands.js"></script>
+    <script src="src/js/state.js"></script>
     <script src="src/js/main.js"></script>
     <script src="src/js/editor.js"></script>
 

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -8,6 +8,8 @@
   const introEl = document.getElementById('intro');
   const copyBtn = document.getElementById('copy-btn');
   const addBtn = document.getElementById('add-btn');
+  const shareBtn = document.getElementById('share-btn');
+  const resetBtn = document.getElementById('reset-btn');
   const scriptEl = document.getElementById('script');
   const scriptCommandsEl = document.getElementById('script-commands');
   const copyScriptBtn = document.getElementById('copy-script-btn');
@@ -200,12 +202,7 @@
     }
 
     function updateHash(v){
-      const params = new URLSearchParams({ scenario: s.id });
-      Object.entries(v).forEach(([k,val]) => {
-        if (!val) return;
-        params.set(k, Array.isArray(val) ? val.join(',') : val);
-      });
-      location.hash = params.toString();
+      location.hash = window.buildScenarioHash(s.id, v);
     }
 
     function updateCommand(){
@@ -232,6 +229,32 @@
         commandEl.textContent = `// Error generating command: ${e.message}`;
       }
       updateHash(values);
+    }
+
+    if (shareBtn){
+      shareBtn.onclick = async () => {
+        const vals = getValues();
+        const hash = window.buildScenarioHash(s.id, vals);
+        const url = `${location.origin}${location.pathname}#${hash}`;
+        try {
+          await navigator.clipboard.writeText(url);
+          shareBtn.textContent = 'Link Copied!';
+          setTimeout(()=>{ shareBtn.textContent = 'Permalink'; }, 1200);
+        } catch {
+          const ta = document.createElement('textarea');
+          ta.value = url; document.body.appendChild(ta); ta.select();
+          document.execCommand('copy'); document.body.removeChild(ta);
+        }
+      };
+    }
+    if (resetBtn){
+      resetBtn.onclick = () => {
+        activeId = null;
+        detailsEl.classList.add('hidden');
+        outputEl.classList.add('hidden');
+        introEl.classList.remove('hidden');
+        location.hash = '';
+      };
     }
 
     updateCommand();

--- a/src/js/state.js
+++ b/src/js/state.js
@@ -1,0 +1,27 @@
+(function(global){
+  function buildScenarioHash(id, values = {}) {
+    const params = new URLSearchParams({ scenario: id });
+    Object.entries(values).forEach(([k, v]) => {
+      if (!v) return;
+      params.set(k, Array.isArray(v) ? v.join(',') : v);
+    });
+    return params.toString();
+  }
+
+  function parseScenarioHash(hash) {
+    const params = new URLSearchParams(hash.startsWith('#') ? hash.slice(1) : hash);
+    const id = params.get('scenario');
+    const values = {};
+    params.forEach((v, k) => {
+      if (k === 'scenario') return;
+      values[k] = v.includes(',') ? v.split(',') : v;
+    });
+    return { id, values };
+  }
+
+  if (typeof module !== 'undefined') {
+    module.exports = { buildScenarioHash, parseScenarioHash };
+  }
+  global.buildScenarioHash = buildScenarioHash;
+  global.parseScenarioHash = parseScenarioHash;
+})(typeof globalThis !== 'undefined' ? globalThis : window);

--- a/tests/js/state.test.js
+++ b/tests/js/state.test.js
@@ -1,0 +1,14 @@
+const { buildScenarioHash, parseScenarioHash } = require('../../src/js/state');
+
+describe('state helpers', () => {
+  test('buildScenarioHash serializes values', () => {
+    const hash = buildScenarioHash('abc', { foo: 'bar', list: ['a','b'] });
+    expect(hash).toBe('scenario=abc&foo=bar&list=a%2Cb');
+  });
+
+  test('parseScenarioHash parses back', () => {
+    const { id, values } = parseScenarioHash('scenario=abc&foo=bar&list=a%2Cb');
+    expect(id).toBe('abc');
+    expect(values).toEqual({ foo: 'bar', list: ['a','b'] });
+  });
+});


### PR DESCRIPTION
## Summary
- add Permalink button to copy a shareable URL with current scenario values
- add Reset button to clear selected scenario
- factor hash-building logic into `state.js` with tests

## Testing
- `npm test`
- `npm run lint`
- `pwsh -NoLogo -Command "Invoke-Pester -Path tests/ps"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c46d2ca3308324a85945b1da19e547