### PR TITLE
Ensure DirFiles base is wrapped for PowerShell paths

### DIFF
--- a/src/js/commands.js
+++ b/src/js/commands.js
@@ -34,9 +34,18 @@ function toArrayLiteral(input) {
   return items.length ? `@(${items.join(',')})` : '';
 }
 
+function formatBase(baseVar) {
+  const base = baseVar && typeof baseVar === 'string' && baseVar.trim()
+    ? baseVar.trim()
+    : '$adtSession.DirFiles';
+  if (base.startsWith('$(')) return base;
+  if (base.startsWith('$')) return `$(${base})`;
+  return base;
+}
+
 // Build an absolute path using a base variable (e.g., $adtSession.DirFiles)
 function joinPath(baseVar, relPath) {
-  const base = baseVar && typeof baseVar === 'string' ? baseVar : '$adtSession.DirFiles';
+  const base = formatBase(baseVar);
   const rel = String(relPath || '')
     .replace(/`/g, '``')
     .replace(/"/g, '`"');
@@ -46,7 +55,7 @@ function joinPath(baseVar, relPath) {
 // Build an array of absolute paths from a comma/newline list
 function joinPathArray(baseVar, listText) {
   if (!listText) return '';
-  const base = baseVar && typeof baseVar === 'string' ? baseVar : '$adtSession.DirFiles';
+  const base = formatBase(baseVar);
   const items = String(listText)
     .split(/[\n,]/)
     .map(s => s.trim())

--- a/tests/js/commands.test.js
+++ b/tests/js/commands.test.js
@@ -11,7 +11,7 @@ describe('PSADT commands', () => {
       argumentList: '',
       logFileName: ''
     });
-    expect(cmd).toBe('Start-ADTMsiProcess -Action Install -FilePath "$adtSession.DirFiles\\app.msi" -ArgumentList \'/qn\'');
+    expect(cmd).toBe('Start-ADTMsiProcess -Action Install -FilePath "$($adtSession.DirFiles)\\app.msi" -ArgumentList \'/qn\'');
   });
 
   test('converts legacy command', () => {
@@ -41,7 +41,7 @@ describe('PSADT commands', () => {
       installDir: 'C:\\App',
       reboot: 'Default'
     });
-    expect(cmd).toBe('Start-ADTProcess -FilePath "$adtSession.DirFiles\\setup.exe" -ArgumentList \'/S INSTALLDIR="C:\\App"\'');
+    expect(cmd).toBe('Start-ADTProcess -FilePath "$($adtSession.DirFiles)\\setup.exe" -ArgumentList \'/S INSTALLDIR="C:\\App"\'');
   });
 
   test('builds winget install command', () => {


### PR DESCRIPTION
## Summary
- ensure generated file paths wrap $adtSession.DirFiles-like bases with PowerShell subexpression syntax
- update array join helper to reuse the same base formatting logic
- adjust unit tests to expect the new $($adtSession.DirFiles) output

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca993202d883249610f5e9efb42564