### PR TITLE
Handle wrapping of PowerShell base paths with appended segments

### DIFF
--- a/src/js/commands.js
+++ b/src/js/commands.js
@@ -39,7 +39,8 @@ function formatBase(baseVar) {
     ? baseVar.trim()
     : '$adtSession.DirFiles';
   if (base.startsWith('$(')) return base;
-  if (base.startsWith('$')) return `$(${base})`;
+  const bareVariablePattern = /^\$[A-Za-z_][\w:]*([.][A-Za-z_][\w]*)*$/;
+  if (bareVariablePattern.test(base)) return `$(${base})`;
   return base;
 }
 


### PR DESCRIPTION
## Summary
- only wrap PowerShell base strings in `$()` when they are bare variable/property references

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb9939f89c8324bacad9bc5f25cdba