### PR TITLE
Add PSADT variable helper panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -315,6 +315,34 @@
             </select>
           </div>
         </div>
+        <div class="card variable-card">
+          <h3 class="card-title">
+            <svg class="icon"><use href="#ic-files" /></svg
+            ><span>Variable Helper</span>
+          </h3>
+          <p class="variable-hint">
+            Based on the
+            <a
+              href="https://psappdeploytoolkit.com/docs/reference/variables"
+              target="_blank"
+              rel="noreferrer"
+              >PSADT 4.1 variable reference</a
+            >.
+            <span id="variable-count" class="variable-count" aria-live="polite"></span>
+          </p>
+          <input
+            type="search"
+            id="variable-search"
+            class="variable-search"
+            placeholder="Search variables"
+            aria-label="Search variables"
+          />
+          <div
+            id="variable-results"
+            class="variable-results"
+            aria-live="polite"
+          ></div>
+        </div>
       </aside>
     </main>
 
@@ -336,6 +364,7 @@
     <script src="src/js/telemetry.js"></script>
     <script src="src/js/commands.js"></script>
     <script src="src/js/state.js"></script>
+    <script src="src/js/variables.js"></script>
     <script src="src/js/main.js"></script>
     <script src="src/js/editor.js"></script>
   </body>

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -18,6 +18,9 @@
   const copyScriptBtn = document.getElementById('copy-script-btn');
   const downloadScriptBtn = document.getElementById('download-script-btn');
   const shareScriptBtn = document.getElementById('share-script-btn');
+  const variableSearchEl = document.getElementById('variable-search');
+  const variableResultsEl = document.getElementById('variable-results');
+  const variableCountEl = document.getElementById('variable-count');
   const accentEl = document.getElementById('accent');
   const swatchesEl = document.getElementById('accent-swatches');
   const bgEl = document.getElementById('background');
@@ -25,59 +28,213 @@
   const modeSel = document.getElementById('color-mode');
   const telemetryToggle = document.getElementById('telemetry-toggle');
   if (telemetryToggle) {
-    telemetryToggle.addEventListener('change', e => setTelemetry(e.target.checked));
+    telemetryToggle.addEventListener('change', (e) =>
+      setTelemetry(e.target.checked),
+    );
   }
-  document.querySelectorAll('img[data-hide-on-error]').forEach(img => {
+  document.querySelectorAll('img[data-hide-on-error]').forEach((img) => {
     img.addEventListener('error', () => img.classList.add('hidden'));
   });
 
-  function applyMode(mode){
+  function applyMode(mode) {
     document.documentElement.removeAttribute('data-theme');
-    if (mode === 'dark' || mode === 'hc'){
+    if (mode === 'dark' || mode === 'hc') {
       document.documentElement.setAttribute('data-theme', mode);
     }
   }
-  if (modeSel){
-    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  if (modeSel) {
+    const prefersDark = window.matchMedia(
+      '(prefers-color-scheme: dark)',
+    ).matches;
     const saved = localStorage.getItem('color-mode') || 'auto';
     modeSel.value = saved;
     applyMode(saved === 'auto' ? (prefersDark ? 'dark' : 'light') : saved);
-    modeSel.addEventListener('change', e => {
+    modeSel.addEventListener('change', (e) => {
       const val = e.target.value;
       localStorage.setItem('color-mode', val);
       applyMode(val === 'auto' ? (prefersDark ? 'dark' : 'light') : val);
     });
   }
 
-
   let activeId = null;
   const scriptCommands = [];
+  const variableData = Array.isArray(window.PSADT_VARIABLES)
+    ? window.PSADT_VARIABLES
+    : [];
+  const totalVariableCount = variableData.reduce(
+    (sum, section) =>
+      sum + (Array.isArray(section.variables) ? section.variables.length : 0),
+    0,
+  );
+  if (variableCountEl) {
+    variableCountEl.textContent = totalVariableCount
+      ? `${totalVariableCount} variables`
+      : '';
+  }
+
+  async function copyText(text) {
+    if (!text) return false;
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch (err) {
+      try {
+        const ta = document.createElement('textarea');
+        ta.value = text;
+        ta.setAttribute('readonly', '');
+        ta.style.position = 'absolute';
+        ta.style.left = '-9999px';
+        document.body.appendChild(ta);
+        ta.select();
+        const success = document.execCommand('copy');
+        document.body.removeChild(ta);
+        return success;
+      } catch (fallbackErr) {
+        console.error(fallbackErr);
+        return false;
+      }
+    }
+  }
+
+  function renderVariableHelper() {
+    if (!variableResultsEl) return;
+    const term = (variableSearchEl?.value || '').trim().toLowerCase();
+    variableResultsEl.innerHTML = '';
+
+    const sections = variableData
+      .map((section) => {
+        const list = Array.isArray(section.variables) ? section.variables : [];
+        const matches = term
+          ? list.filter((item) => {
+              const name = (item.variable || '').toLowerCase();
+              const desc = (item.description || '').toLowerCase();
+              return name.includes(term) || desc.includes(term);
+            })
+          : list;
+        return { ...section, matches };
+      })
+      .filter((section) => section.matches.length);
+
+    if (!sections.length) {
+      const empty = document.createElement('p');
+      empty.className = 'variable-empty';
+      empty.textContent = term
+        ? 'No variables match your search.'
+        : 'Variable reference is unavailable.';
+      variableResultsEl.appendChild(empty);
+      return;
+    }
+
+    sections.forEach((section, idx) => {
+      const details = document.createElement('details');
+      details.className = 'variable-section';
+      if (term || idx === 0) details.open = true;
+
+      const summary = document.createElement('summary');
+      summary.className = 'variable-section-header';
+      const titleSpan = document.createElement('span');
+      titleSpan.textContent = section.title || 'Section';
+      const countSpan = document.createElement('span');
+      countSpan.className = 'variable-pill';
+      countSpan.textContent = section.matches.length;
+      summary.appendChild(titleSpan);
+      summary.appendChild(countSpan);
+      details.appendChild(summary);
+
+      const body = document.createElement('div');
+      body.className = 'variable-section-body';
+      section.matches.forEach((item) => {
+        const entry = document.createElement('div');
+        entry.className = 'variable-entry';
+
+        const header = document.createElement('div');
+        header.className = 'variable-entry-header';
+        const code = document.createElement('code');
+        code.textContent = item.variable;
+        header.appendChild(code);
+
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'variable-copy-btn';
+        btn.setAttribute('aria-label', `Copy ${item.variable}`);
+        btn.innerHTML =
+          '<svg class="icon"><use href="#ic-copy"></use></svg><span>Copy</span>';
+        btn.addEventListener('click', async (e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          const success = await copyText(item.variable);
+          if (success) {
+            btn.classList.add('copied');
+            const span = btn.querySelector('span');
+            if (span) span.textContent = 'Copied!';
+            setTimeout(() => {
+              btn.classList.remove('copied');
+              if (span) span.textContent = 'Copy';
+            }, 1200);
+          }
+        });
+        header.appendChild(btn);
+
+        const desc = document.createElement('p');
+        desc.className = 'variable-description';
+        desc.textContent = item.description || '';
+
+        entry.appendChild(header);
+        entry.appendChild(desc);
+        body.appendChild(entry);
+      });
+
+      details.appendChild(body);
+      variableResultsEl.appendChild(details);
+    });
+  }
+
+  if (variableResultsEl) {
+    renderVariableHelper();
+  }
+  if (variableSearchEl) {
+    variableSearchEl.addEventListener('input', renderVariableHelper);
+  }
 
   const initialState = new URLSearchParams(location.hash.slice(1));
 
-  function renderList(){
+  function renderList() {
     listEl.innerHTML = '';
-    const scenarios = Array.isArray(window.PSADT_SCENARIOS) ? window.PSADT_SCENARIOS : [];
+    const scenarios = Array.isArray(window.PSADT_SCENARIOS)
+      ? window.PSADT_SCENARIOS
+      : [];
     const term = searchEl ? searchEl.value.toLowerCase() : '';
-    scenarios.filter(s => !term || s.name.toLowerCase().includes(term) || (s.description||'').toLowerCase().includes(term)).forEach(s => {
-      const item = document.createElement('div');
-      item.className = 'scenario-item' + (activeId === s.id ? ' active' : '');
-      item.tabIndex = 0;
-      item.setAttribute('role', 'button');
-      item.setAttribute('aria-pressed', activeId === s.id ? 'true':'false');
-      item.addEventListener('click', () => selectScenario(s.id));
-      item.addEventListener('keydown', (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); selectScenario(s.id); } });
-      const name = document.createElement('span');
-      name.className = 'scenario-name';
-      name.textContent = s.name;
-      const desc = document.createElement('span');
-      desc.className = 'scenario-desc';
-      desc.textContent = s.description || '';
-      item.appendChild(name);
-      item.appendChild(desc);
-      listEl.appendChild(item);
-    });
-    if (!scenarios.length){
+    scenarios
+      .filter(
+        (s) =>
+          !term ||
+          s.name.toLowerCase().includes(term) ||
+          (s.description || '').toLowerCase().includes(term),
+      )
+      .forEach((s) => {
+        const item = document.createElement('div');
+        item.className = 'scenario-item' + (activeId === s.id ? ' active' : '');
+        item.tabIndex = 0;
+        item.setAttribute('role', 'button');
+        item.setAttribute('aria-pressed', activeId === s.id ? 'true' : 'false');
+        item.addEventListener('click', () => selectScenario(s.id));
+        item.addEventListener('keydown', (e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            selectScenario(s.id);
+          }
+        });
+        const name = document.createElement('span');
+        name.className = 'scenario-name';
+        name.textContent = s.name;
+        const desc = document.createElement('span');
+        desc.className = 'scenario-desc';
+        desc.textContent = s.description || '';
+        item.appendChild(name);
+        item.appendChild(desc);
+        listEl.appendChild(item);
+      });
+    if (!scenarios.length) {
       const none = document.createElement('div');
       none.className = 'scenario-item';
       none.textContent = 'No scenarios available.';
@@ -85,11 +242,13 @@
     }
   }
 
-  function selectScenario(id, preset = {}){
+  function selectScenario(id, preset = {}) {
     activeId = id;
     renderList();
-    const list = Array.isArray(window.PSADT_SCENARIOS) ? window.PSADT_SCENARIOS : [];
-    const s = list.find(x => x.id === id);
+    const list = Array.isArray(window.PSADT_SCENARIOS)
+      ? window.PSADT_SCENARIOS
+      : [];
+    const s = list.find((x) => x.id === id);
     if (!s) return;
 
     introEl.classList.add('hidden');
@@ -101,7 +260,7 @@
     title.textContent = s.name;
     detailsEl.appendChild(title);
 
-    if (s.description){
+    if (s.description) {
       const d = document.createElement('p');
       d.textContent = s.description;
       d.style.color = 'var(--muted)';
@@ -112,7 +271,7 @@
     form.className = 'form';
 
     // Build fields
-    s.fields.forEach(field => {
+    s.fields.forEach((field) => {
       const wrap = document.createElement('div');
       wrap.className = 'field';
       const label = document.createElement('label');
@@ -131,9 +290,16 @@
         row.style.gap = '8px';
         baseSel = document.createElement('select');
         baseSel.id = `f_${field.id}_base`;
-        ['($adtSession.DirFiles)','$adtSession.DirFiles','$adtSession.DirSupportFiles'].forEach((opt, idx) => {
+        [
+          '($adtSession.DirFiles)',
+          '$adtSession.DirFiles',
+          '$adtSession.DirSupportFiles',
+        ].forEach((opt, idx) => {
           if (idx === 0) return; // ignore helper first
-          const o = document.createElement('option'); o.value = opt; o.textContent = opt; baseSel.appendChild(o);
+          const o = document.createElement('option');
+          o.value = opt;
+          o.textContent = opt;
+          baseSel.appendChild(o);
         });
         baseSel.value = preset[`${field.id}Base`] || '$adtSession.DirFiles';
         baseSel.addEventListener('change', () => updateCommand());
@@ -142,32 +308,42 @@
       }
 
       // Build the input element
-      if (field.type === 'textarea'){
+      if (field.type === 'textarea') {
         input = document.createElement('textarea');
-      } else if (field.type === 'select'){
+      } else if (field.type === 'select') {
         input = document.createElement('select');
         const empty = document.createElement('option');
         empty.value = '';
         empty.textContent = '—';
         input.appendChild(empty);
-        (field.options || []).forEach(opt => {
+        (field.options || []).forEach((opt) => {
           const o = document.createElement('option');
-          if (typeof opt === 'object') { o.value = opt.value; o.textContent = opt.label || opt.value; }
-          else { o.value = opt; o.textContent = opt; }
+          if (typeof opt === 'object') {
+            o.value = opt.value;
+            o.textContent = opt.label || opt.value;
+          } else {
+            o.value = opt;
+            o.textContent = opt;
+          }
           input.appendChild(o);
         });
-      } else if (field.type === 'multiselect'){
+      } else if (field.type === 'multiselect') {
         input = document.createElement('select');
         input.multiple = true;
-        (field.options || []).forEach(opt => {
+        (field.options || []).forEach((opt) => {
           const o = document.createElement('option');
-          if (typeof opt === 'object') { o.value = opt.value; o.textContent = opt.label || opt.value; }
-          else { o.value = opt; o.textContent = opt; }
+          if (typeof opt === 'object') {
+            o.value = opt.value;
+            o.textContent = opt.label || opt.value;
+          } else {
+            o.value = opt;
+            o.textContent = opt;
+          }
           input.appendChild(o);
         });
         // Make multi-select taller
         input.size = Math.min(8, (field.options || []).length || 4);
-      } else if (field.type === 'number'){
+      } else if (field.type === 'number') {
         input = document.createElement('input');
         input.type = 'number';
         if (field.min != null) input.min = field.min;
@@ -180,7 +356,10 @@
       input.name = field.id;
       if (field.placeholder) input.placeholder = field.placeholder;
       if (field.required) input.required = true;
-      if (field.pattern) { input.pattern = field.pattern; if (field.patternMessage) input.title = field.patternMessage; }
+      if (field.pattern) {
+        input.pattern = field.pattern;
+        if (field.patternMessage) input.title = field.patternMessage;
+      }
 
       input.addEventListener('input', () => updateCommand());
       wrap.appendChild(label);
@@ -192,9 +371,15 @@
       }
       form.appendChild(wrap);
       const presetVal = preset[field.id];
-      if (presetVal !== undefined){
-        if (field.type === 'multiselect' && Array.isArray(presetVal) && input instanceof HTMLSelectElement){
-          Array.from(input.options).forEach(o => { o.selected = presetVal.includes(o.value); });
+      if (presetVal !== undefined) {
+        if (
+          field.type === 'multiselect' &&
+          Array.isArray(presetVal) &&
+          input instanceof HTMLSelectElement
+        ) {
+          Array.from(input.options).forEach((o) => {
+            o.selected = presetVal.includes(o.value);
+          });
         } else {
           input.value = presetVal;
         }
@@ -203,13 +388,17 @@
 
     detailsEl.appendChild(form);
 
-    function getValues(){
+    function getValues() {
       const values = {};
-      s.fields.forEach(field => {
+      s.fields.forEach((field) => {
         const el = form.querySelector(`#f_${field.id}`);
         let val;
-        if (field.type === 'multiselect' && el instanceof HTMLSelectElement && el.multiple){
-          val = Array.from(el.selectedOptions).map(o => o.value);
+        if (
+          field.type === 'multiselect' &&
+          el instanceof HTMLSelectElement &&
+          el.multiple
+        ) {
+          val = Array.from(el.selectedOptions).map((o) => o.value);
         } else {
           val = el.value;
         }
@@ -217,62 +406,66 @@
         values[field.id] = val;
         if (field.fileBase) {
           const base = form.querySelector(`#f_${field.id}_base`);
-          values[`${field.id}Base`] = base ? base.value : '$adtSession.DirFiles';
+          values[`${field.id}Base`] = base
+            ? base.value
+            : '$adtSession.DirFiles';
         }
       });
       return values;
     }
 
-    function updateHash(v){
+    function updateHash(v) {
       location.hash = window.buildScenarioHash(s.id, v);
     }
 
-    function updateCommand(){
+    function updateCommand() {
       const values = getValues();
-      const missing = s.fields.filter(f => f.required && !values[f.id]);
-      const invalid = s.fields.filter(f => {
+      const missing = s.fields.filter((f) => f.required && !values[f.id]);
+      const invalid = s.fields.filter((f) => {
         const el = form.querySelector(`#f_${f.id}`);
         return el && !el.checkValidity();
       });
-      if (missing.length){
-        commandEl.textContent = `// Missing: ${missing.map(m => m.label).join(', ')}`;
+      if (missing.length) {
+        commandEl.textContent = `// Missing: ${missing.map((m) => m.label).join(', ')}`;
         updateHash(values);
         return;
       }
-      if (invalid.length){
-        commandEl.textContent = `// Invalid: ${invalid.map(m => m.label).join(', ')}`;
+      if (invalid.length) {
+        commandEl.textContent = `// Invalid: ${invalid.map((m) => m.label).join(', ')}`;
         updateHash(values);
         return;
       }
       try {
         const cmd = s.build(values);
         commandEl.textContent = cmd || '';
-      } catch (e){
+      } catch (e) {
         commandEl.textContent = `// Error generating command: ${e.message}`;
       }
       updateHash(values);
     }
 
-    if (shareBtn){
+    if (shareBtn) {
       shareBtn.onclick = async () => {
         const vals = getValues();
         const hash = window.buildScenarioHash(s.id, vals);
         const url = `${location.origin}${location.pathname}#${hash}`;
-        try {
-          await navigator.clipboard.writeText(url);
+        const success = await copyText(url);
+        if (success) {
           shareBtn.textContent = 'Link Copied!';
-          setTimeout(()=>{ shareBtn.textContent = 'Permalink'; }, 1200);
-        } catch {
-          const ta = document.createElement('textarea');
-          ta.value = url; document.body.appendChild(ta); ta.select();
-          document.execCommand('copy'); document.body.removeChild(ta);
+          setTimeout(() => {
+            shareBtn.textContent = 'Permalink';
+          }, 1200);
+        } else {
+          window.prompt('Copy this link', url);
         }
       };
     }
-    if (exportBtn){
+    if (exportBtn) {
       exportBtn.onclick = () => {
         const data = { id: s.id, values: getValues() };
-        const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+        const blob = new Blob([JSON.stringify(data, null, 2)], {
+          type: 'application/json',
+        });
         const a = document.createElement('a');
         a.href = URL.createObjectURL(blob);
         a.download = `${s.id}.json`;
@@ -282,7 +475,7 @@
         URL.revokeObjectURL(a.href);
       };
     }
-    if (resetBtn){
+    if (resetBtn) {
       resetBtn.onclick = () => {
         activeId = null;
         detailsEl.classList.add('hidden');
@@ -295,7 +488,7 @@
     updateCommand();
   }
 
-  if (importBtn && importFile){
+  if (importBtn && importFile) {
     importBtn.addEventListener('click', () => importFile.click());
     importFile.addEventListener('change', () => {
       const file = importFile.files[0];
@@ -305,7 +498,9 @@
         try {
           const data = JSON.parse(reader.result);
           if (data.id) selectScenario(data.id, data.values || {});
-        } catch (e){ console.error(e); }
+        } catch (e) {
+          console.error(e);
+        }
       };
       reader.readAsText(file);
       importFile.value = '';
@@ -316,20 +511,18 @@
     logEvent('copyCommand', { id: activeId });
     const txt = commandEl.textContent || '';
     if (!txt.trim()) return;
-    try {
-      await navigator.clipboard.writeText(txt);
+    const success = await copyText(txt);
+    if (success) {
       copyBtn.textContent = 'Copied!';
       copyBtn.style.background = 'var(--ok)';
-      setTimeout(() => { copyBtn.textContent = 'Copy'; copyBtn.style.background = ''; }, 1200);
-    } catch {
-      // fallback
-      const ta = document.createElement('textarea');
-      ta.value = txt; document.body.appendChild(ta); ta.select();
-      document.execCommand('copy'); document.body.removeChild(ta);
+      setTimeout(() => {
+        copyBtn.textContent = 'Copy';
+        copyBtn.style.background = '';
+      }, 1200);
     }
   });
 
-  function renderScript(){
+  function renderScript() {
     scriptCommandsEl.innerHTML = '';
     scriptCommands.forEach((cmd, idx) => {
       const row = document.createElement('div');
@@ -338,27 +531,44 @@
       pre.className = 'code';
       pre.textContent = cmd;
       pre.contentEditable = 'true';
-      pre.addEventListener('input', () => { scriptCommands[idx] = pre.textContent; });
+      pre.addEventListener('input', () => {
+        scriptCommands[idx] = pre.textContent;
+      });
       const tools = document.createElement('div');
       tools.className = 'script-row-tools';
-      const up = document.createElement('button'); up.textContent = '↑'; up.className = 'script-btn'; up.title = 'Move up'; up.addEventListener('click', () => moveScript(idx,-1));
-      const down = document.createElement('button'); down.textContent = '↓'; down.className = 'script-btn'; down.title = 'Move down'; down.addEventListener('click', () => moveScript(idx,1));
-      const del = document.createElement('button'); del.textContent = '×'; del.className = 'script-btn'; del.title = 'Remove'; del.addEventListener('click', () => removeScript(idx));
-      tools.appendChild(up); tools.appendChild(down); tools.appendChild(del);
-      row.appendChild(pre); row.appendChild(tools);
+      const up = document.createElement('button');
+      up.textContent = '↑';
+      up.className = 'script-btn';
+      up.title = 'Move up';
+      up.addEventListener('click', () => moveScript(idx, -1));
+      const down = document.createElement('button');
+      down.textContent = '↓';
+      down.className = 'script-btn';
+      down.title = 'Move down';
+      down.addEventListener('click', () => moveScript(idx, 1));
+      const del = document.createElement('button');
+      del.textContent = '×';
+      del.className = 'script-btn';
+      del.title = 'Remove';
+      del.addEventListener('click', () => removeScript(idx));
+      tools.appendChild(up);
+      tools.appendChild(down);
+      tools.appendChild(del);
+      row.appendChild(pre);
+      row.appendChild(tools);
       scriptCommandsEl.appendChild(row);
     });
     scriptEl.classList.toggle('hidden', scriptCommands.length === 0);
   }
-  function moveScript(idx, delta){
+  function moveScript(idx, delta) {
     const n = idx + delta;
     if (n < 0 || n >= scriptCommands.length) return;
-    const [cmd] = scriptCommands.splice(idx,1);
-    scriptCommands.splice(n,0,cmd);
+    const [cmd] = scriptCommands.splice(idx, 1);
+    scriptCommands.splice(n, 0, cmd);
     renderScript();
   }
-  function removeScript(idx){
-    scriptCommands.splice(idx,1);
+  function removeScript(idx) {
+    scriptCommands.splice(idx, 1);
     renderScript();
   }
   addBtn.addEventListener('click', () => {
@@ -371,107 +581,144 @@
   copyScriptBtn.addEventListener('click', async () => {
     const txt = scriptCommands.join('\n');
     if (!txt.trim()) return;
-    try {
-      await navigator.clipboard.writeText(txt);
+    const success = await copyText(txt);
+    if (success) {
       copyScriptBtn.textContent = 'Copied!';
-      setTimeout(() => { copyScriptBtn.textContent = 'Copy Script'; }, 1200);
-    } catch {
-      const ta = document.createElement('textarea');
-      ta.value = txt; document.body.appendChild(ta); ta.select();
-      document.execCommand('copy'); document.body.removeChild(ta);
+      setTimeout(() => {
+        copyScriptBtn.textContent = 'Copy Script';
+      }, 1200);
     }
   });
-    downloadScriptBtn.addEventListener('click', () => {
+  downloadScriptBtn.addEventListener('click', () => {
+    const txt = scriptCommands.join('\n');
+    if (!txt.trim()) return;
+    const blob = new Blob([txt], { type: 'text/plain' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'psadt-script.ps1';
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  });
+  if (shareScriptBtn) {
+    shareScriptBtn.addEventListener('click', async () => {
       const txt = scriptCommands.join('\n');
       if (!txt.trim()) return;
-      const blob = new Blob([txt], { type: 'text/plain' });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = 'psadt-script.ps1';
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-      URL.revokeObjectURL(url);
+      const b64 = btoa(txt);
+      const url = `${location.origin}${location.pathname}#script=${encodeURIComponent(b64)}`;
+      const success = await copyText(url);
+      if (success) {
+        shareScriptBtn.textContent = 'Link Copied!';
+        setTimeout(() => {
+          shareScriptBtn.textContent = 'Copy Link';
+        }, 1200);
+      } else {
+        window.prompt('Copy this link', url);
+      }
     });
-    if (shareScriptBtn){
-      shareScriptBtn.addEventListener('click', async () => {
-        const txt = scriptCommands.join('\n');
-        if (!txt.trim()) return;
-        const b64 = btoa(txt);
-        const url = `${location.origin}${location.pathname}#script=${encodeURIComponent(b64)}`;
-        try {
-          await navigator.clipboard.writeText(url);
-          shareScriptBtn.textContent = 'Link Copied!';
-          setTimeout(()=>{ shareScriptBtn.textContent = 'Copy Link'; }, 1200);
-        } catch {
-          const ta = document.createElement('textarea'); ta.value = url; document.body.appendChild(ta); ta.select(); document.execCommand('copy'); document.body.removeChild(ta);
-        }
-      });
-    }
-    // Initial render
+  }
+  // Initial render
   renderList();
   if (searchEl) searchEl.addEventListener('input', renderList);
-  if (initialState.get('scenario')){
+  if (initialState.get('scenario')) {
     const id = initialState.get('scenario');
     const vals = {};
-    initialState.forEach((v,k) => {
+    initialState.forEach((v, k) => {
       if (k === 'scenario') return;
       if (k === 'script') return;
       vals[k] = v.includes(',') ? v.split(',') : v;
     });
     selectScenario(id, vals);
   }
-  if (initialState.get('script')){
+  if (initialState.get('script')) {
     try {
       const decoded = atob(initialState.get('script'));
-      decoded.split('\n').forEach(c => { if (c.trim()) scriptCommands.push(c); });
+      decoded.split('\n').forEach((c) => {
+        if (c.trim()) scriptCommands.push(c);
+      });
       renderScript();
-    } catch (e) { /* ignore */ }
+    } catch (e) {
+      /* ignore */
+    }
   }
 
   // Theming: accent color persistence and contrast handling
-  function hexToRgb(hex){
+  function hexToRgb(hex) {
     const m = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
-    if (!m) return null; return { r: parseInt(m[1],16), g: parseInt(m[2],16), b: parseInt(m[3],16) };
+    if (!m) return null;
+    return {
+      r: parseInt(m[1], 16),
+      g: parseInt(m[2], 16),
+      b: parseInt(m[3], 16),
+    };
   }
-  function relativeLuma({r,g,b}){
+  function relativeLuma({ r, g, b }) {
     // Simple sRGB luminance
-    const toLin = (c)=>{ c/=255; return c<=0.03928? c/12.92: Math.pow((c+0.055)/1.055,2.4) };
-    const R=toLin(r), G=toLin(g), B=toLin(b); return 0.2126*R + 0.7152*G + 0.0722*B;
+    const toLin = (c) => {
+      c /= 255;
+      return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+    };
+    const R = toLin(r),
+      G = toLin(g),
+      B = toLin(b);
+    return 0.2126 * R + 0.7152 * G + 0.0722 * B;
   }
-  function contrastRatio(c1,c2){
-    const L1 = relativeLuma(c1)+0.05; const L2 = relativeLuma(c2)+0.05; return L1>L2? L1/L2 : L2/L1;
+  function contrastRatio(c1, c2) {
+    const L1 = relativeLuma(c1) + 0.05;
+    const L2 = relativeLuma(c2) + 0.05;
+    return L1 > L2 ? L1 / L2 : L2 / L1;
   }
-  function setAccent(color){
+  function setAccent(color) {
     if (!color) return;
     document.documentElement.style.setProperty('--accent', color);
     const rgb = hexToRgb(color);
-    if (rgb){
-      const white = {r:255,g:255,b:255};
-      const dark = {r:11,g:14,b:24};
+    if (rgb) {
+      const white = { r: 255, g: 255, b: 255 };
+      const dark = { r: 11, g: 14, b: 24 };
       const cWhite = contrastRatio(rgb, white);
       const cDark = contrastRatio(rgb, dark);
-      document.documentElement.style.setProperty('--accent-contrast', cWhite >= cDark ? '#ffffff' : '#0b0e18');
+      document.documentElement.style.setProperty(
+        '--accent-contrast',
+        cWhite >= cDark ? '#ffffff' : '#0b0e18',
+      );
     }
-    try { localStorage.setItem('psadtAccent', color); } catch (e) { /* ignore */ }
+    try {
+      localStorage.setItem('psadtAccent', color);
+    } catch (e) {
+      /* ignore */
+    }
     if (accentEl) accentEl.value = color;
   }
-  function clamp(n,min,max){ return Math.max(min, Math.min(max, n)); }
-  function hex(n){ const s = clamp(Math.round(n),0,255).toString(16).padStart(2,'0'); return s; }
-  function mix(c1,c2,ratio){
-    const a = hexToRgb(c1), b = hexToRgb(c2); if(!a||!b) return c1;
-    const r = a.r*(1-ratio)+b.r*ratio, g=a.g*(1-ratio)+b.g*ratio, b2=a.b*(1-ratio)+b.b*ratio;
+  function clamp(n, min, max) {
+    return Math.max(min, Math.min(max, n));
+  }
+  function hex(n) {
+    const s = clamp(Math.round(n), 0, 255).toString(16).padStart(2, '0');
+    return s;
+  }
+  function mix(c1, c2, ratio) {
+    const a = hexToRgb(c1),
+      b = hexToRgb(c2);
+    if (!a || !b) return c1;
+    const r = a.r * (1 - ratio) + b.r * ratio,
+      g = a.g * (1 - ratio) + b.g * ratio,
+      b2 = a.b * (1 - ratio) + b.b * ratio;
     return `#${hex(r)}${hex(g)}${hex(b2)}`;
   }
-  function setBackground(color){
+  function setBackground(color) {
     if (!color) return;
-    const rgb = hexToRgb(color); if (!rgb) return;
+    const rgb = hexToRgb(color);
+    if (!rgb) return;
     document.documentElement.style.setProperty('--bg', color);
     const l = relativeLuma(rgb);
     // Derive panel/border/text based on background luminance
-    let text = '#e6e7ee', muted = '#a1a6c5', panel, border;
-    if (l >= 0.6){
+    let text = '#e6e7ee',
+      muted = '#a1a6c5',
+      panel,
+      border;
+    if (l >= 0.6) {
       // Light background
       text = '#0b0e18';
       muted = '#3f4865';
@@ -488,29 +735,74 @@
     document.documentElement.style.setProperty('--border', border);
     document.documentElement.style.setProperty('--text', text);
     document.documentElement.style.setProperty('--muted', muted);
-    try { localStorage.setItem('psadtBg', color); } catch (e) { /* ignore */ }
+    try {
+      localStorage.setItem('psadtBg', color);
+    } catch (e) {
+      /* ignore */
+    }
     if (bgEl) bgEl.value = color;
   }
-  const saved = (()=>{ try { return localStorage.getItem('psadtAccent'); } catch { return null } })();
+  const saved = (() => {
+    try {
+      return localStorage.getItem('psadtAccent');
+    } catch {
+      return null;
+    }
+  })();
   if (saved) setAccent(saved);
-  if (accentEl){ accentEl.addEventListener('input', (e)=> setAccent(e.target.value)); }
-  if (swatchesEl){ swatchesEl.addEventListener('click', (e)=>{
-    const btn = e.target.closest('.swatch'); if (!btn) return; const c = btn.getAttribute('data-color'); setAccent(c);
-  }); }
-  const savedBg = (()=>{ try { return localStorage.getItem('psadtBg'); } catch { return null } })();
+  if (accentEl) {
+    accentEl.addEventListener('input', (e) => setAccent(e.target.value));
+  }
+  if (swatchesEl) {
+    swatchesEl.addEventListener('click', (e) => {
+      const btn = e.target.closest('.swatch');
+      if (!btn) return;
+      const c = btn.getAttribute('data-color');
+      setAccent(c);
+    });
+  }
+  const savedBg = (() => {
+    try {
+      return localStorage.getItem('psadtBg');
+    } catch {
+      return null;
+    }
+  })();
   if (savedBg) setBackground(savedBg);
-  if (bgEl){ bgEl.addEventListener('input', (e)=> setBackground(e.target.value)); }
-  if (bgSwatchesEl){ bgSwatchesEl.addEventListener('click', (e)=>{
-    const btn = e.target.closest('.swatch'); if (!btn) return; const c = btn.getAttribute('data-color'); setBackground(c);
-  }); }
+  if (bgEl) {
+    bgEl.addEventListener('input', (e) => setBackground(e.target.value));
+  }
+  if (bgSwatchesEl) {
+    bgSwatchesEl.addEventListener('click', (e) => {
+      const btn = e.target.closest('.swatch');
+      if (!btn) return;
+      const c = btn.getAttribute('data-color');
+      setBackground(c);
+    });
+  }
 
   // Hidden gimmick: classic Konami code reveals a surprise
-  const secret = ['ArrowUp','ArrowUp','ArrowDown','ArrowDown','ArrowLeft','ArrowRight','ArrowLeft','ArrowRight','b','a'];
+  const secret = [
+    'ArrowUp',
+    'ArrowUp',
+    'ArrowDown',
+    'ArrowDown',
+    'ArrowLeft',
+    'ArrowRight',
+    'ArrowLeft',
+    'ArrowRight',
+    'b',
+    'a',
+  ];
   const buffer = [];
   window.addEventListener('keydown', (e) => {
     buffer.push(e.key);
     if (buffer.length > secret.length) buffer.shift();
-    if (secret.every((k,i) => k.toLowerCase() === (buffer[i] || '').toLowerCase())){
+    if (
+      secret.every(
+        (k, i) => k.toLowerCase() === (buffer[i] || '').toLowerCase(),
+      )
+    ) {
       alert('🍕 You found the hidden pizza!');
       buffer.length = 0;
     }

--- a/src/js/variables.js
+++ b/src/js/variables.js
@@ -1,0 +1,599 @@
+const PSADT_VARIABLES = [
+  {
+    id: 'toolkit-name',
+    title: 'Toolkit Name',
+    variables: [
+      {
+        variable: '$appDeployMainScriptFriendlyName',
+        description: 'Full name of toolkit including spaces',
+      },
+      {
+        variable: '$appDeployToolkitName',
+        description: 'Short-name of toolkit without spaces',
+      },
+    ],
+  },
+  {
+    id: 'script-info',
+    title: 'Script Info',
+    variables: [
+      {
+        variable: '$appDeployMainScriptVersion',
+        description: 'Version number of the PSAppDeployToolkit',
+      },
+    ],
+  },
+  {
+    id: 'culture',
+    title: 'Culture',
+    variables: [
+      {
+        variable: '$culture',
+        description:
+          'Object which contains all of the current Windows culture settings',
+      },
+      {
+        variable: '$currentLanguage',
+        description:
+          'Current Windows two letter ISO language name (e.g. EN, FR, DE, JA etc)',
+      },
+      {
+        variable: '$currentUILanguage',
+        description:
+          'Current Windows two letter UI ISO language name (e.g. EN, FR, DE, JA etc)',
+      },
+    ],
+  },
+  {
+    id: 'environment-variables',
+    title: 'Environment Variables',
+    variables: [
+      {
+        variable: '$envAllUsersProfile',
+        description: '%ALLUSERSPROFILE%, e.g. C:\\ProgramData',
+      },
+      {
+        variable: '$envAppData',
+        description: '%APPDATA%, e.g. C:\\Users\\%USERNAME%\\AppData\\Roaming',
+      },
+      {
+        variable: '$envArchitecture',
+        description:
+          '%PROCESSOR_ARCHITECTURE%, e.g. AMD64/IA64/x86.Note - This doesn\'t tell you the architecture of the processor but only of the current process, so it returns "x86" for a 32-bit WOW process running on 64-bit Windows.',
+      },
+      {
+        variable: '$envCommonDesktop',
+        description: 'e.g. C:\\Users\\Public\\Desktop',
+      },
+      {
+        variable: '$envCommonDocuments',
+        description: 'e.g. C:\\Users\\Public\\Documents',
+      },
+      {
+        variable: '$envCommonProgramFiles',
+        description:
+          '%COMMONPROGRAMFILES%, e.g. C:\\Program Files\\Common Files)',
+      },
+      {
+        variable: '$envCommonProgramFilesX86',
+        description:
+          '%COMMONPROGRAMFILES(x86)%, e.g. C:\\Program Files (x86)\\Common Files',
+      },
+      {
+        variable: '$envCommonStartMenu',
+        description: 'e.g. C:\\ProgramData\\Microsoft\\Windows\\Start Menu',
+      },
+      {
+        variable: '$envCommonStartMenuPrograms',
+        description:
+          'e.g. C:\\ProgramData\\Microsoft\\Windows\\Start Menu\\Programs',
+      },
+      {
+        variable: '$envCommonStartUp',
+        description:
+          'e.g. C:\\ProgramData\\Microsoft\\Windows\\Start Menu\\Programs\\Startup',
+      },
+      {
+        variable: '$envCommonTemplates',
+        description: 'e.g. C:\\ProgramData\\Microsoft\\Windows\\Templates',
+      },
+      {
+        variable: '$envComputerName',
+        description: '$COMPUTERNAME%, e.g. Computer1',
+      },
+      {
+        variable: '$envComputerNameFQDN',
+        description:
+          'Fully qualified computer name, e.g. computer1.contoso.com',
+      },
+      {
+        variable: '$envHomeDrive',
+        description: '%HOMEDRIVE%, e.g. C:',
+      },
+      {
+        variable: '$envHomePath',
+        description: '%HOMEPATH%, e.g. C:\\Users\\%USERNAME%',
+      },
+      {
+        variable: '$envHomeShare',
+        description:
+          '%HOMESHARE% (Used instead of HOMEDRIVE if the home folder uses UNC paths.)',
+      },
+      {
+        variable: '$envLocalAppData',
+        description:
+          '%LOCALAPPDATA%, e.g. C:\\Users\\%USERNAME%\\AppData\\Local',
+      },
+      {
+        variable: '$envLogicalDrives',
+        description:
+          'An array containing all of the logical drives on the system.',
+      },
+      {
+        variable: '$envProgramData',
+        description: '%PROGRAMDATA%, e.g. C:\\ProgramData',
+      },
+      {
+        variable: '$envProgramFiles',
+        description: '%PROGRAMFILES%, e.g. C:\\Program Files',
+      },
+      {
+        variable: '$envProgramFilesX86',
+        description:
+          '%ProgramFiles(x86)%, e.g. C:\\Program Files (x86) (Only on 64 bit. Used to store 32 bit apps.)',
+      },
+      {
+        variable: '$envPublic',
+        description: '%PUBLIC%, e.g. C:\\Users\\Public',
+      },
+      {
+        variable: '$envSystem32Directory',
+        description: 'C:\\WINDOWS\\system32',
+      },
+      {
+        variable: '$envSystemDrive',
+        description: '%SYSTEMDRIVE%, e.g. C:',
+      },
+      {
+        variable: '$envSystemRAM',
+        description: 'System RAM as an integer',
+      },
+      {
+        variable: '$envSystemRoot',
+        description: '%SYSTEMROOT%, e.g. C:\\Windows',
+      },
+      {
+        variable: '$envTemp',
+        description:
+          'Checks for the existence of environment variables in the following order and uses the first path found:- The path specified by TEMP environment variable, (e.g. C:\\Users\\%USERNAME%\\AppData\\Local\\Temp).- The path specified by the USERPROFILE environment variable.- The Windows root (C:\\Windows) folder.',
+      },
+      {
+        variable: '$envUserCookies',
+        description:
+          'C:\\Users\\%USERNAME%\\AppData\\Local\\Microsoft\\Windows\\INetCookies',
+      },
+      {
+        variable: '$envUserDesktop',
+        description: 'C:\\Users\\%USERNAME%\\Desktop',
+      },
+      {
+        variable: '$envUserFavorites',
+        description: 'C:\\Users\\%USERNAME%\\Favorites',
+      },
+      {
+        variable: '$envUserInternetCache',
+        description:
+          'C:\\Users\\%USERNAME%\\AppData\\Local\\Microsoft\\Windows\\INetCache',
+      },
+      {
+        variable: '$envUserInternetHistory',
+        description:
+          'C:\\Users\\%USERNAME%\\AppData\\Local\\Microsoft\\Windows\\History',
+      },
+      {
+        variable: '$envUserMyDocuments',
+        description: 'C:\\Users\\%USERNAME%\\Documents',
+      },
+      {
+        variable: '$envUserName',
+        description: '%USERNAME%',
+      },
+      {
+        variable: '$envUserProfile',
+        description: '%USERPROFILE%, e.g. %SystemDrive%\\Users\\%USERNAME%',
+      },
+      {
+        variable: '$envUserSendTo',
+        description:
+          'C:\\Users\\%USERNAME%\\AppData\\Roaming\\Microsoft\\Windows\\SendTo',
+      },
+      {
+        variable: '$envUserStartMenu',
+        description:
+          'C:\\Users\\%USERNAME%\\AppData\\Roaming\\Microsoft\\Windows\\Start Menu',
+      },
+      {
+        variable: '$envUserStartMenuPrograms',
+        description:
+          'C:\\Users\\%USERNAME%\\AppData\\Roaming\\Microsoft\\Windows\\Start Menu\\Programs',
+      },
+      {
+        variable: '$envUserStartUp',
+        description:
+          'C:\\Users\\%USERNAME%\\AppData\\Roaming\\Microsoft\\Windows\\Start Menu\\Programs\\Startup',
+      },
+      {
+        variable: '$envWinDir',
+        description: '%WINDIR%, e.g. C:\\Windows',
+      },
+    ],
+  },
+  {
+    id: 'domain-membership',
+    title: 'Domain Membership',
+    variables: [
+      {
+        variable: '$envLogonServer',
+        description:
+          'FQDN of %LOGONSERVER% used for authenticating logged in user',
+      },
+      {
+        variable: '$envMachineADDomain',
+        description: 'Root AD domain name for machine, e.g. domain.contoso.com',
+      },
+      {
+        variable: '$envMachineDNSDomain',
+        description: 'Full Domain name for machine, e.g. <name>.contoso.com',
+      },
+      {
+        variable: '$envMachineWorkgroup',
+        description:
+          'If machine not joined to domain, what is the WORKGROUP it belongs to?',
+      },
+      {
+        variable: '$envUserDNSDomain',
+        description:
+          '%USERDNSDOMAIN%. Root AD domain name for user, e.g. domain.contoso.com',
+      },
+      {
+        variable: '$envUserDomain',
+        description: '%USERDOMAIN%, e.g. domain.contoso.com',
+      },
+      {
+        variable: '$IsMachinePartOfDomain',
+        description: 'Is machine joined to a domain, e.g. $true/$false',
+      },
+      {
+        variable: '$MachineDomainController',
+        description: 'FQDN of an AD domain controller used for authentication',
+      },
+    ],
+  },
+  {
+    id: 'operating-system',
+    title: 'Operating System',
+    variables: [
+      {
+        variable: '$envOS',
+        description: 'Object that contains details about the operating system',
+      },
+      {
+        variable: '$envOSArchitecture',
+        description: 'Represents the OS architecture (e.g. 32-Bit/64-Bit)',
+      },
+      {
+        variable: '$envOSName',
+        description:
+          'Name of the operating system (e.g. Microsoft Windows 8.1 Pro)',
+      },
+      {
+        variable: '$envOSProductType',
+        description: 'OS product type represented as an integer (e.g. 1/2/3)',
+      },
+      {
+        variable: '$envOSProductTypeName',
+        description:
+          'OS product type name (e.g. Server/Domain Controller/Workstation/Unknown)',
+      },
+      {
+        variable: '$envOSServicePack',
+        description:
+          'Latest service pack installed on the system (e.g. Service Pack 3)',
+      },
+      {
+        variable: '$envOSVersion',
+        description:
+          'Full version number of the OS (e.g. <major>.<minor>.<build>.<revision>)',
+      },
+      {
+        variable: '$envOSVersionBuild',
+        description:
+          'Build portion of the OS version number (e.g. <major>.<minor>.<build>.<revision>)',
+      },
+      {
+        variable: '$envOSVersionMajor',
+        description:
+          'Major portion of the OS version number (e.g. <major>.<minor>.<build>.<revision>)',
+      },
+      {
+        variable: '$envOSVersionMinor',
+        description:
+          'Minor portion of the OS version number (e.g. <major>.<minor>.<build>.<revision>)',
+      },
+      {
+        variable: '$envOSVersionRevision',
+        description:
+          'Revision portion of the OS version number (e.g. <major>.<minor>.<build>.<revision>)',
+      },
+      {
+        variable: '$Is64Bit',
+        description: 'Is this a 64-bit OS? (e.g. $true/$false)',
+      },
+      {
+        variable: '$IsDomainControllerOS',
+        description: 'Is domain controller OS? (e.g. $true/$false)',
+      },
+      {
+        variable: '$IsServerOS',
+        description: 'Is server OS? (e.g. $true/$false)',
+      },
+      {
+        variable: '$IsWorkStationOS',
+        description: 'Is workstation OS? (e.g. $true/$false)',
+      },
+    ],
+  },
+  {
+    id: 'current-process-architecture',
+    title: 'Current Process Architecture',
+    variables: [
+      {
+        variable: '$Is64BitProcess',
+        description: 'Is the current process 64-bits? (e.g. $true/$false)',
+      },
+      {
+        variable: '$psArchitecture',
+        description:
+          'Represents the current process architecture (e.g. x86/x64)',
+      },
+    ],
+  },
+  {
+    id: 'powershell-and-clr-net-versions',
+    title: 'PowerShell And CLR (.NET) Versions',
+    variables: [
+      {
+        variable: '$envCLRVersion',
+        description:
+          'Full version number of .NET used by PS (e.g. <major>.<minor>.<build>.<revision>)',
+      },
+      {
+        variable: '$envCLRVersionBuild',
+        description:
+          'Build portion of PS .NET version number (e.g. <major>.<minor>.<build>.<revision>)',
+      },
+      {
+        variable: '$envCLRVersionMajor',
+        description:
+          'Major portion of PS .NET version number (e.g. <major>.<minor>.<build>.<revision>)',
+      },
+      {
+        variable: '$envCLRVersionMinor',
+        description:
+          'Minor portion of PS .NET version number (e.g. <major>.<minor>.<build>.<revision>)',
+      },
+      {
+        variable: '$envCLRVersionRevision',
+        description:
+          'Revision portion of PS .NET version number (e.g. <major>.<minor>.<build>.<revision>)',
+      },
+      {
+        variable: '$envHost',
+        description:
+          'Object that contains details about the current PowerShell console',
+      },
+      {
+        variable: '$envPSVersion',
+        description:
+          'Full version number of PS (e.g. <major>.<minor>.<build>.<revision>)',
+      },
+      {
+        variable: '$envPSVersionBuild',
+        description:
+          'Build portion of PS version number (e.g. <major>.<minor>.<build>.<revision>)',
+      },
+      {
+        variable: '$envPSVersionMajor',
+        description:
+          'Major portion of PS version number (e.g. <major>.<minor>.<build>.<revision>)',
+      },
+      {
+        variable: '$envPSVersionMinor',
+        description:
+          'Minor portion of PS version number (e.g. <major>.<minor>.<build>.<revision>)',
+      },
+      {
+        variable: '$envPSVersionRevision',
+        description:
+          'Revision portion of PS version number (e.g. <major>.<minor>.<build>.<revision>)',
+      },
+      {
+        variable: '$envPSVersionTable',
+        description:
+          'Object containing PowerShell version details from PS variable $PSVersionTable',
+      },
+    ],
+  },
+  {
+    id: 'permissions--accounts',
+    title: 'Permissions / Accounts',
+    variables: [
+      {
+        variable: '$CurrentProcessSID',
+        description:
+          'Object that represents the current process account SID (e.g. S-1-5-32-544)',
+      },
+      {
+        variable: '$CurrentProcessToken',
+        description:
+          'Object that represents the current processes Windows Identity user token. Contains all details regarding user permissions.',
+      },
+      {
+        variable: '$IsAdmin',
+        description:
+          'Is the current process running with elevated admin privileges? (e.g. $true/$false)',
+      },
+      {
+        variable: '$IsLocalServiceAccount',
+        description:
+          'Is the current process running under LOCAL SERVICE account? (e.g. $true/$false)',
+      },
+      {
+        variable: '$IsLocalSystemAccount',
+        description:
+          'Is the current process running under the SYSTEM account? (e.g. $true/$false)',
+      },
+      {
+        variable: '$IsNetworkServiceAccount',
+        description:
+          'Is the current process running under the NETWORK SERVICE account? (e.g. $true/$false)',
+      },
+      {
+        variable: '$IsProcessUserInteractive',
+        description: 'Is the current process able to display a user interface?',
+      },
+      {
+        variable: '$IsServiceAccount',
+        description:
+          'Is the current process running as a service? (e.g. $true/$false)',
+      },
+      {
+        variable: '$LocalSystemNTAccount',
+        description:
+          'Localized NT account name of the SYSTEM account (e.g. NT AUTHORITY\\SYSTEM)',
+      },
+      {
+        variable: '$ProcessNTAccount',
+        description: 'Current process NT Account (e.g. NT AUTHORITY\\SYSTEM)',
+      },
+      {
+        variable: '$ProcessNTAccountSID',
+        description: 'Current process account SID (e.g. S-1-5-32-544)',
+      },
+      {
+        variable: '$SessionZero',
+        description:
+          'Is the current process currently in session zero? In session zero isolation, process is not able to display a user interface. (e.g. $true/$false)',
+      },
+    ],
+  },
+  {
+    id: 'regex-patterns',
+    title: 'RegEx Patterns',
+    variables: [
+      {
+        variable: '$MSIProductCodeRegExPattern',
+        description:
+          'Contains the regex pattern used to detect a MSI product code',
+      },
+    ],
+  },
+  {
+    id: 'com-objects',
+    title: 'COM Objects',
+    variables: [
+      {
+        variable: '$Shell',
+        description:
+          'Represents and allows use of the WScript.Shell COM object',
+      },
+      {
+        variable: '$ShellApp',
+        description:
+          'Represents and allows use of the Shell.Application COM object',
+      },
+    ],
+  },
+  {
+    id: 'logged-on-users',
+    title: 'Logged On Users',
+    variables: [
+      {
+        variable: '$CurrentConsoleUserSession',
+        description:
+          'Objects that contains the account and session details of the console user (user with control of the physical monitor, keyboard, and mouse). This is the object from $LoggedOnUserSessions where the IsConsoleSession property is $true.',
+      },
+      {
+        variable: '$CurrentLoggedOnUserSession',
+        description:
+          'Object that contains account and session details for the current process if it is running as a logged in user. This is the object from $LoggedOnUserSessions where the IsCurrentSession property is $true.',
+      },
+      {
+        variable: '$LoggedOnUserSessions',
+        description:
+          'Object that contains account and session details for all users',
+      },
+      {
+        variable: '$RunAsActiveUser',
+        description:
+          'The active console user. If no console user exists but users are logged in, such as on terminal servers, then the first logged-in non-console user.',
+      },
+      {
+        variable: '$UsersLoggedOn',
+        description:
+          'Array that contains all of the NTAccount names of logged in users',
+      },
+    ],
+  },
+  {
+    id: 'microsoft-office',
+    title: 'Microsoft Office',
+    variables: [
+      {
+        variable: 'envOfficeBitness',
+        description:
+          'Architecture of current Office installation, e.g. x86 or x64',
+      },
+      {
+        variable: 'envOfficeChannel',
+        description: "Current Office Channel, e.g. 'Monthly Enterprise'",
+      },
+      {
+        variable: 'envOfficeVars',
+        description:
+          'Properties of HKLM\\SOFTWARE\\Microsoft\\Office\\ClickToRun\\Configuration',
+      },
+      {
+        variable: 'envOfficeVersion',
+        description: 'Microsoft Office version, e.g. 16.0.x.x',
+      },
+    ],
+  },
+  {
+    id: 'miscellaneous',
+    title: 'Miscellaneous',
+    variables: [
+      {
+        variable: '$invalidFileNameChars',
+        description:
+          'Array of all invalid file name characters used to sanitize variables which may be used to create file names.',
+      },
+      {
+        variable: '$LocalAdministratorsGroup',
+        description:
+          'Returns the name of the local Administrators group, typically BUILTIN\\Administrators',
+      },
+      {
+        variable: '$LocalUsersGroup',
+        description:
+          'Returns the name of the local Users group, typically BUILTIN\\Users',
+      },
+      {
+        variable: '$RunningTaskSequence',
+        description:
+          'Is the current process running in a SCCM task sequence? (e.g. $true / $false)',
+      },
+    ],
+  },
+];
+window.PSADT_VARIABLES = PSADT_VARIABLES;

--- a/styles.css
+++ b/styles.css
@@ -216,6 +216,143 @@ body {
 .tools .card {
   margin: 0;
 }
+.variable-card {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.variable-hint {
+  margin: 0;
+  font-size: 12px;
+  color: var(--muted);
+}
+.variable-hint a {
+  color: var(--accent);
+  text-decoration: none;
+}
+.variable-hint a:hover {
+  text-decoration: underline;
+}
+.variable-count {
+  font-weight: 600;
+  margin-left: 4px;
+}
+.variable-search {
+  width: 100%;
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+}
+.variable-results {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-height: calc(100vh - 360px);
+  overflow: auto;
+  padding-right: 4px;
+}
+.variable-results:focus-visible {
+  outline: none;
+}
+.variable-section {
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--panel) 85%, var(--bg) 15%);
+  overflow: hidden;
+}
+.variable-section summary {
+  list-style: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 10px 12px;
+  font-size: 13px;
+  color: var(--muted);
+  user-select: none;
+}
+.variable-section summary::-webkit-details-marker {
+  display: none;
+}
+.variable-section[open] summary {
+  color: var(--text);
+}
+.variable-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 24px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--border) 60%, transparent);
+  font-size: 11px;
+  color: var(--muted);
+  font-weight: 600;
+}
+.variable-section-body {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 0 12px 12px;
+}
+.variable-entry {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--panel) 90%, var(--bg) 10%);
+  padding: 10px 12px;
+}
+.variable-entry-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+.variable-entry code {
+  font-size: 12px;
+  background: color-mix(in srgb, var(--border) 70%, transparent);
+  border-radius: 6px;
+  padding: 3px 6px;
+  border: 1px solid var(--border);
+}
+.variable-description {
+  margin: 0;
+  font-size: 12px;
+  color: var(--muted);
+}
+.variable-copy-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 8px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: var(--panel);
+  color: var(--text);
+  font-size: 12px;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+.variable-copy-btn:hover {
+  background: color-mix(in srgb, var(--accent) 10%, var(--panel) 90%);
+}
+.variable-copy-btn svg {
+  width: 14px;
+  height: 14px;
+}
+.variable-copy-btn.copied {
+  background: var(--ok);
+  color: var(--accent-contrast);
+  border-color: transparent;
+}
+.variable-empty {
+  margin: 0;
+  font-size: 13px;
+  color: var(--muted);
+}
 .full {
   width: 100%;
 }


### PR DESCRIPTION
## Summary
- add a variable helper card with search and copy actions sourced from the PSADT 4.1 documentation
- share a reusable clipboard helper so command and script actions share the same fallback logic
- bundle the PSADT 4.1 variable catalog for the helper panel

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb98518a348324b60abef58e97fbaa