### PR TITLE
Restructure variable helper into collapsible usage guide

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -144,15 +144,51 @@
       const body = document.createElement('div');
       body.className = 'variable-section-body';
       section.matches.forEach((item) => {
-        const entry = document.createElement('div');
+        const entry = document.createElement('details');
         entry.className = 'variable-entry';
+        if (term) entry.open = true;
 
-        const header = document.createElement('div');
-        header.className = 'variable-entry-header';
+        const summary = document.createElement('summary');
+        summary.className = 'variable-entry-summary';
         const code = document.createElement('code');
         code.textContent = item.variable;
-        header.appendChild(code);
+        summary.appendChild(code);
+        entry.appendChild(summary);
 
+        const entryBody = document.createElement('div');
+        entryBody.className = 'variable-entry-body';
+
+        const descGroup = document.createElement('div');
+        descGroup.className = 'variable-meta';
+        const descLabel = document.createElement('span');
+        descLabel.className = 'variable-meta-label';
+        descLabel.textContent = 'Description';
+        const desc = document.createElement('p');
+        desc.className = 'variable-description';
+        desc.textContent = item.description || 'No description available.';
+        descGroup.appendChild(descLabel);
+        descGroup.appendChild(desc);
+
+        const usageGroup = document.createElement('div');
+        usageGroup.className = 'variable-meta';
+        const usageLabel = document.createElement('span');
+        usageLabel.className = 'variable-meta-label';
+        usageLabel.textContent = 'How to use';
+        const usage = document.createElement('p');
+        usage.className = 'variable-usage';
+        if (item.usage) {
+          usage.innerHTML = item.usage;
+        } else {
+          usage.innerHTML =
+            'Reference <code>' +
+            item.variable +
+            '</code> in your deployment script wherever you need to access this value.';
+        }
+        usageGroup.appendChild(usageLabel);
+        usageGroup.appendChild(usage);
+
+        const actions = document.createElement('div');
+        actions.className = 'variable-entry-actions';
         const btn = document.createElement('button');
         btn.type = 'button';
         btn.className = 'variable-copy-btn';
@@ -173,14 +209,12 @@
             }, 1200);
           }
         });
-        header.appendChild(btn);
+        actions.appendChild(btn);
 
-        const desc = document.createElement('p');
-        desc.className = 'variable-description';
-        desc.textContent = item.description || '';
-
-        entry.appendChild(header);
-        entry.appendChild(desc);
+        entryBody.appendChild(descGroup);
+        entryBody.appendChild(usageGroup);
+        entryBody.appendChild(actions);
+        entry.appendChild(entryBody);
         body.appendChild(entry);
       });
 

--- a/styles.css
+++ b/styles.css
@@ -297,19 +297,35 @@ body {
   padding: 0 12px 12px;
 }
 .variable-entry {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
   border: 1px solid var(--border);
   border-radius: 8px;
   background: color-mix(in srgb, var(--panel) 90%, var(--bg) 10%);
-  padding: 10px 12px;
+  overflow: hidden;
 }
-.variable-entry-header {
+.variable-entry summary {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 12px;
+  padding: 12px;
+  cursor: pointer;
+  list-style: none;
+}
+.variable-entry summary::after {
+  content: '▾';
+  font-size: 12px;
+  color: var(--muted);
+  transition: transform 0.2s ease;
+}
+.variable-entry[open] summary::after {
+  transform: rotate(180deg);
+}
+.variable-entry summary::-webkit-details-marker {
+  display: none;
+}
+.variable-entry summary:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 .variable-entry code {
   font-size: 12px;
@@ -318,10 +334,37 @@ body {
   padding: 3px 6px;
   border: 1px solid var(--border);
 }
-.variable-description {
+.variable-entry-body {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 0 12px 12px;
+  border-top: 1px solid var(--border);
+}
+.variable-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.variable-meta-label {
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+}
+.variable-description,
+.variable-usage {
   margin: 0;
   font-size: 12px;
   color: var(--muted);
+}
+.variable-usage code {
+  font-size: 12px;
+}
+.variable-entry-actions {
+  display: flex;
+  justify-content: flex-end;
 }
 .variable-copy-btn {
   display: inline-flex;


### PR DESCRIPTION
## Summary
- rebuild the variable helper entries using nested details so the list is collapsed by default
- surface dedicated description and "how to use" sections for each variable with an inline copy action
- refresh styling for the new expandable layout including toggling indicators and spacing

## Testing
- npm run lint
- npm test -- --runTestsByPath

------
https://chatgpt.com/codex/tasks/task_e_68cb9d6adae083249050c7f0022c6876