### PR TITLE
Redesign variable helper to match command builder

### DIFF
--- a/index.html
+++ b/index.html
@@ -337,11 +337,16 @@
             placeholder="Search variables"
             aria-label="Search variables"
           />
-          <div
-            id="variable-results"
-            class="variable-results"
-            aria-live="polite"
-          ></div>
+          <div class="variable-helper">
+            <div id="variable-results" class="variable-results"></div>
+            <div
+              id="variable-detail"
+              class="variable-detail empty"
+              aria-live="polite"
+            >
+              <p class="variable-empty">Select a variable to see details.</p>
+            </div>
+          </div>
         </div>
       </aside>
     </main>

--- a/src/js/variables.js
+++ b/src/js/variables.js
@@ -550,21 +550,21 @@ const PSADT_VARIABLES = [
     title: 'Microsoft Office',
     variables: [
       {
-        variable: 'envOfficeBitness',
+        variable: '$envOfficeBitness',
         description:
           'Architecture of current Office installation, e.g. x86 or x64',
       },
       {
-        variable: 'envOfficeChannel',
+        variable: '$envOfficeChannel',
         description: "Current Office Channel, e.g. 'Monthly Enterprise'",
       },
       {
-        variable: 'envOfficeVars',
+        variable: '$envOfficeVars',
         description:
           'Properties of HKLM\\SOFTWARE\\Microsoft\\Office\\ClickToRun\\Configuration',
       },
       {
-        variable: 'envOfficeVersion',
+        variable: '$envOfficeVersion',
         description: 'Microsoft Office version, e.g. 16.0.x.x',
       },
     ],

--- a/styles.css
+++ b/styles.css
@@ -243,40 +243,34 @@ body {
   border: 1px solid var(--border);
   border-radius: 10px;
 }
+.variable-helper {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
 .variable-results {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 12px;
   max-height: calc(100vh - 360px);
   overflow: auto;
   padding-right: 4px;
 }
-.variable-results:focus-visible {
-  outline: none;
-}
 .variable-section {
-  border: 1px solid var(--border);
-  border-radius: 10px;
-  background: color-mix(in srgb, var(--panel) 85%, var(--bg) 15%);
-  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
-.variable-section summary {
-  list-style: none;
-  cursor: pointer;
+.variable-section-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 8px;
-  padding: 10px 12px;
-  font-size: 13px;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
   color: var(--muted);
-  user-select: none;
-}
-.variable-section summary::-webkit-details-marker {
-  display: none;
-}
-.variable-section[open] summary {
-  color: var(--text);
 }
 .variable-pill {
   display: inline-flex;
@@ -286,60 +280,96 @@ body {
   padding: 2px 8px;
   border-radius: 999px;
   background: color-mix(in srgb, var(--border) 60%, transparent);
-  font-size: 11px;
-  color: var(--muted);
+  font-size: 10px;
   font-weight: 600;
+  color: var(--muted);
 }
 .variable-section-body {
   display: flex;
-  flex-direction: column;
-  gap: 8px;
-  padding: 0 12px 12px;
+  flex-wrap: wrap;
+  gap: 6px;
 }
-.variable-entry {
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  background: color-mix(in srgb, var(--panel) 90%, var(--bg) 10%);
-  overflow: hidden;
-}
-.variable-entry summary {
-  display: flex;
+.variable-item {
+  display: inline-flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  padding: 12px;
-  cursor: pointer;
-  list-style: none;
-}
-.variable-entry summary::after {
-  content: '▾';
+  justify-content: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: color-mix(in srgb, var(--panel) 92%, var(--bg) 8%);
+  color: var(--text);
   font-size: 12px;
-  color: var(--muted);
-  transition: transform 0.2s ease;
+  cursor: pointer;
+  transition:
+    background 0.2s ease,
+    border-color 0.2s ease,
+    box-shadow 0.2s ease,
+    color 0.2s ease;
 }
-.variable-entry[open] summary::after {
-  transform: rotate(180deg);
+.variable-item:hover {
+  background: color-mix(in srgb, var(--accent) 12%, var(--panel) 88%);
+  border-color: color-mix(in srgb, var(--accent) 45%, var(--border) 55%);
 }
-.variable-entry summary::-webkit-details-marker {
-  display: none;
-}
-.variable-entry summary:focus-visible {
+.variable-item:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
 }
-.variable-entry code {
-  font-size: 12px;
-  background: color-mix(in srgb, var(--border) 70%, transparent);
-  border-radius: 6px;
-  padding: 3px 6px;
-  border: 1px solid var(--border);
+.variable-item.active {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--accent-contrast);
+  box-shadow: 0 10px 24px rgba(23, 91, 235, 0.2);
 }
-.variable-entry-body {
+.variable-detail {
+  min-height: 140px;
+  border: 1px dashed var(--border);
+  border-radius: 12px;
+  padding: 12px;
+  background: color-mix(in srgb, var(--panel) 95%, var(--bg) 5%);
   display: flex;
   flex-direction: column;
   gap: 12px;
-  padding: 0 12px 12px;
-  border-top: 1px solid var(--border);
+}
+.variable-detail.empty {
+  justify-content: center;
+  text-align: center;
+  color: var(--muted);
+}
+.variable-detail-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+.variable-detail-title {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.variable-detail code {
+  font-size: 13px;
+  background: color-mix(in srgb, var(--border) 70%, transparent);
+  border-radius: 6px;
+  padding: 4px 8px;
+  border: 1px solid var(--border);
+}
+.variable-section-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+  color: var(--accent);
+  font-size: 11px;
+  font-weight: 600;
+}
+.variable-detail-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 .variable-meta {
   display: flex;
@@ -362,15 +392,11 @@ body {
 .variable-usage code {
   font-size: 12px;
 }
-.variable-entry-actions {
-  display: flex;
-  justify-content: flex-end;
-}
 .variable-copy-btn {
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  padding: 4px 8px;
+  padding: 4px 10px;
   border-radius: 999px;
   border: 1px solid var(--border);
   background: var(--panel);


### PR DESCRIPTION
## Summary
- restyle the variable helper card so the PSADT variables are shown as selectable tiles beside the command builder
- add a dedicated detail panel that reveals the selected variable's description, usage guidance, and copy control
- refresh styles to align the helper with the command builder experience while keeping accessibility cues

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb9eae58d48324a8d36e2524786b42