### PR TITLE
Show full variable helper list without search filter

### DIFF
--- a/index.html
+++ b/index.html
@@ -330,13 +330,6 @@
             >.
             <span id="variable-count" class="variable-count" aria-live="polite"></span>
           </p>
-          <input
-            type="search"
-            id="variable-search"
-            class="variable-search"
-            placeholder="Search variables"
-            aria-label="Search variables"
-          />
           <div class="variable-helper">
             <div id="variable-results" class="variable-results"></div>
             <div

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -18,7 +18,6 @@
   const copyScriptBtn = document.getElementById('copy-script-btn');
   const downloadScriptBtn = document.getElementById('download-script-btn');
   const shareScriptBtn = document.getElementById('share-script-btn');
-  const variableSearchEl = document.getElementById('variable-search');
   const variableResultsEl = document.getElementById('variable-results');
   const variableDetailEl = document.getElementById('variable-detail');
   const variableCountEl = document.getElementById('variable-count');
@@ -199,35 +198,23 @@
 
   function renderVariableHelper() {
     if (!variableResultsEl) return;
-    const term = (variableSearchEl?.value || '').trim().toLowerCase();
     variableResultsEl.innerHTML = '';
 
     const sections = variableData
-      .map((section) => {
-        const list = Array.isArray(section.variables) ? section.variables : [];
-        const matches = term
-          ? list.filter((item) => {
-              const name = (item.variable || '').toLowerCase();
-              const desc = (item.description || '').toLowerCase();
-              return name.includes(term) || desc.includes(term);
-            })
-          : list;
-        return { ...section, matches };
-      })
+      .map((section) => ({
+        ...section,
+        matches: Array.isArray(section.variables) ? section.variables : [],
+      }))
       .filter((section) => section.matches.length);
 
     if (!sections.length) {
       const empty = document.createElement('p');
       empty.className = 'variable-empty';
-      empty.textContent = term
-        ? 'No variables match your search.'
-        : 'Variable reference is unavailable.';
+      empty.textContent = 'Variable reference is unavailable.';
       variableResultsEl.appendChild(empty);
       activeVariableKey = null;
       activeVariableButton = null;
-      setVariableDetail(
-        term ? 'No variables match your search.' : 'Select a variable to see details.',
-      );
+      setVariableDetail('Select a variable to see details.');
       return;
     }
 
@@ -280,9 +267,6 @@
 
   if (variableResultsEl) {
     renderVariableHelper();
-  }
-  if (variableSearchEl) {
-    variableSearchEl.addEventListener('input', renderVariableHelper);
   }
 
   const initialState = new URLSearchParams(location.hash.slice(1));

--- a/styles.css
+++ b/styles.css
@@ -237,12 +237,6 @@ body {
   font-weight: 600;
   margin-left: 4px;
 }
-.variable-search {
-  width: 100%;
-  padding: 8px 10px;
-  border: 1px solid var(--border);
-  border-radius: 10px;
-}
 .variable-helper {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- remove the variable helper search input so the reference is always visible
- update the helper rendering logic to always render every variable section without filtering
- clean up the unused search styling

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68cba16e465c832483f02629a600369e