### PR TITLE
Add modal popup for PSADT variable details

### DIFF
--- a/index.html
+++ b/index.html
@@ -359,6 +359,28 @@
       >
     </footer>
 
+    <div
+      id="variable-modal"
+      class="modal hidden"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="variable-modal-title"
+    >
+      <div class="modal-overlay" data-modal-dismiss></div>
+      <div class="modal-container" role="document">
+        <button
+          type="button"
+          class="modal-close"
+          id="variable-modal-close"
+          data-modal-dismiss
+          aria-label="Close variable details"
+        >
+          <span aria-hidden="true">&times;</span>
+        </button>
+        <div id="variable-modal-body" class="modal-body"></div>
+      </div>
+    </div>
+
     <script src="src/js/telemetry.js"></script>
     <script src="src/js/commands.js"></script>
     <script src="src/js/state.js"></script>

--- a/styles.css
+++ b/styles.css
@@ -416,6 +416,61 @@ body {
   font-size: 13px;
   color: var(--muted);
 }
+
+.modal {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal-overlay {
+  position: absolute;
+  inset: 0;
+  background: color-mix(in srgb, var(--bg) 40%, #000 60%);
+  opacity: 0.7;
+}
+
+.modal-container {
+  position: relative;
+  z-index: 1;
+  background: var(--panel);
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+  padding: 24px;
+  max-width: min(520px, calc(100% - 40px));
+  width: min(520px, calc(100% - 40px));
+}
+
+.modal-body {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  color: var(--text);
+}
+
+.modal-close {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  background: transparent;
+  border: none;
+  color: var(--muted);
+  font-size: 22px;
+  cursor: pointer;
+  padding: 6px;
+  border-radius: 999px;
+}
+
+.modal-close:hover,
+.modal-close:focus-visible {
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+  color: var(--accent);
+  outline: none;
+}
 .full {
   width: 100%;
 }


### PR DESCRIPTION
## Summary
- add a modal overlay so variable details can appear in the center of the interface
- refactor variable helper rendering to reuse shared builders for the sidebar and modal content
- style the modal container, overlay, and close control to match the app theme

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cbbcb4d04883248e88b41076e12752