### PR TITLE
Add v4 function mapping reference page

### DIFF
--- a/docs/reference/v4-function-mapping/index.html
+++ b/docs/reference/v4-function-mapping/index.html
@@ -1,0 +1,132 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>PSAppDeployToolkit v4 Function Mapping</title>
+    <link rel="stylesheet" href="/styles.css" />
+    <style>
+      body {
+        background: #0e0e14;
+        color: #f6f6f9;
+        font-family: "Segoe UI", Roboto, sans-serif;
+        margin: 0;
+        min-height: 100vh;
+      }
+      a {
+        color: #8cc2ff;
+      }
+      header {
+        background: #161624;
+        border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+        padding: 24px 32px;
+      }
+      header h1 {
+        margin: 0;
+        font-size: 1.75rem;
+      }
+      main {
+        max-width: 960px;
+        margin: 0 auto;
+        padding: 32px 16px 64px;
+      }
+      .lead {
+        font-size: 1.1rem;
+        margin-bottom: 24px;
+      }
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        margin-bottom: 32px;
+      }
+      th,
+      td {
+        padding: 12px 16px;
+        border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+        text-align: left;
+      }
+      th {
+        font-size: 0.95rem;
+        letter-spacing: 0.02em;
+        text-transform: uppercase;
+      }
+      tbody tr:hover {
+        background: rgba(140, 194, 255, 0.05);
+      }
+      .notes {
+        background: rgba(255, 255, 255, 0.04);
+        padding: 16px 20px;
+        border-radius: 8px;
+      }
+      footer {
+        text-align: center;
+        font-size: 0.85rem;
+        color: rgba(246, 246, 249, 0.6);
+        padding: 24px 16px 32px;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>PSAppDeployToolkit v4 Function Mapping</h1>
+      <p class="lead">
+        Use this reference to translate frequently used PSAppDeployToolkit 3.x helper
+        functions to their 4.x equivalents.
+      </p>
+    </header>
+    <main>
+      <p>
+        The mappings below are the same values used by the <code>Convert-LegacyCommand</code>
+        helper that ships with the Cloudcook PSADT Helper PowerShell module. Legacy
+        commands on the left are rewritten to the modern names shown on the right.
+      </p>
+      <table>
+        <thead>
+          <tr>
+            <th scope="col">3.x Function</th>
+            <th scope="col">4.x Function</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>Execute-MSI</code></td>
+            <td><code>Start-ADTMsiProcess</code></td>
+          </tr>
+          <tr>
+            <td><code>Execute-MSP</code></td>
+            <td><code>Start-ADTMspProcess</code></td>
+          </tr>
+          <tr>
+            <td><code>Execute-Process</code></td>
+            <td><code>Start-ADTProcess</code></td>
+          </tr>
+          <tr>
+            <td><code>Show-InstallationWelcome</code></td>
+            <td><code>Show-ADTInstallationWelcome</code></td>
+          </tr>
+          <tr>
+            <td><code>Show-InstallationPrompt</code></td>
+            <td><code>Show-ADTInstallationPrompt</code></td>
+          </tr>
+          <tr>
+            <td><code>Show-InstallationProgress</code></td>
+            <td><code>Show-ADTInstallationProgress</code></td>
+          </tr>
+          <tr>
+            <td><code>Show-InstallationRestartPrompt</code></td>
+            <td><code>Show-ADTInstallationRestartPrompt</code></td>
+          </tr>
+        </tbody>
+      </table>
+      <div class="notes">
+        <p>
+          Tip: the PSADT Helper's <strong>Legacy Converter</strong> can also update renamed
+          parameters when you paste older scripts into the tool.
+        </p>
+      </div>
+    </main>
+    <footer>
+      <a href="/">Back to PSADT Helper</a>
+    </footer>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a static reference page for PSAppDeployToolkit v4 function mappings
- mirror the helper module mapping data in a formatted table with supporting context
- provide navigation back to the main PSADT Helper experience

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68cbbeaa2ad0832487ebc8c737a78979