### PR TITLE
Enhance command builder with parameter metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -226,6 +226,13 @@
             aria-label="PSADT commands"
           ></div>
           <div
+            id="command-detail"
+            class="cmd-detail empty"
+            aria-live="polite"
+          >
+            <p>Select a command to view parameters.</p>
+          </div>
+          <div
             id="editor-area"
             class="cmd-editor"
             contenteditable="true"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "lint": "eslint src/js tests/js",
     "fmt": "prettier --write \"src/js/**/*.js\" \"tests/js/**/*.js\"",
     "test": "jest",
-    "build:legacy": "node scripts/update-legacy-mapping.js"
+    "build:legacy": "node scripts/update-legacy-mapping.js",
+    "build:commands": "node scripts/build-command-metadata.js"
   },
   "devDependencies": {
     "eslint": "^8.57.0",

--- a/scripts/build-command-metadata.js
+++ b/scripts/build-command-metadata.js
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+const sourcePath = path.join(__dirname, '..', 'psadt', 'PSAppDeployToolkit', 'PSAppDeployToolkit.psm1');
+const outputPath = path.join(__dirname, '..', 'src', 'data', 'command-metadata.json');
+
+function normalizeText(block) {
+  return block
+    .split(/\r?\n/)
+    .map(line => line.trim())
+    .filter(Boolean)
+    .join(' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function parseCommentBlock(raw) {
+  if (!raw) {
+    return {
+      synopsis: '',
+      description: '',
+      link: '',
+      parameters: [],
+    };
+  }
+  const body = raw
+    .replace(/^\s*<#/, '')
+    .replace(/#>\s*$/, '');
+  const synopsisMatch = body.match(/\.SYNOPSIS\s*\r?\n([\s\S]*?)(?=\r?\n\s*\.[A-Z]|$)/);
+  const descriptionMatch = body.match(/\.DESCRIPTION\s*\r?\n([\s\S]*?)(?=\r?\n\s*\.[A-Z]|$)/);
+  const linkMatch = body.match(/\.LINK\s*\r?\n([\s\S]*?)(?=\r?\n\s*\.[A-Z]|$)/);
+
+  const parameters = [];
+  const paramRegex = /\.PARAMETER\s+([^\r\n]+)\r?\n([\s\S]*?)(?=\r?\n\s*\.[A-Z]|\r?\n\s*#>|$)/g;
+  let match;
+  while ((match = paramRegex.exec(body)) !== null) {
+    const name = match[1].trim();
+    const desc = normalizeText(match[2]);
+    if (name) {
+      parameters.push({ name, description: desc });
+    }
+  }
+
+  return {
+    synopsis: synopsisMatch ? normalizeText(synopsisMatch[1]) : '',
+    description: descriptionMatch ? normalizeText(descriptionMatch[1]) : '',
+    link: linkMatch ? normalizeText(linkMatch[1]) : '',
+    parameters,
+  };
+}
+
+function buildMetadata() {
+  if (!fs.existsSync(sourcePath)) {
+    throw new Error(`Source file not found at ${sourcePath}`);
+  }
+  const text = fs.readFileSync(sourcePath, 'utf8');
+  const metadata = [];
+  const fnRegex = /function\s+([A-Za-z0-9-]+)\s*\{/g;
+  let match;
+  while ((match = fnRegex.exec(text)) !== null) {
+    const name = match[1];
+    const start = match.index + match[0].length;
+    const remainder = text.slice(start);
+    const nextFunctionMatch = remainder.match(/\nfunction\s+[A-Za-z0-9-]+\s*\{/);
+    const section = nextFunctionMatch ? remainder.slice(0, nextFunctionMatch.index) : remainder;
+    const commentMatch = section.match(/<#[\s\S]*?#>/);
+    const comment = commentMatch ? commentMatch[0] : '';
+    const info = parseCommentBlock(comment);
+    metadata.push({
+      name,
+      synopsis: info.synopsis,
+      description: info.description,
+      link: info.link,
+      parameters: info.parameters,
+    });
+  }
+  metadata.sort((a, b) => a.name.localeCompare(b.name));
+  return metadata;
+}
+
+function main() {
+  const metadata = buildMetadata();
+  fs.writeFileSync(outputPath, `${JSON.stringify(metadata, null, 2)}\n`, 'utf8');
+  console.log(`Wrote ${metadata.length} commands to ${outputPath}`);
+}
+
+main();

--- a/src/data/command-metadata.json
+++ b/src/data/command-metadata.json
@@ -1,0 +1,3489 @@
+[
+  {
+    "name": "Add-ADTEdgeExtension",
+    "synopsis": "Adds an extension for Microsoft Edge using the ExtensionSettings policy.",
+    "description": "This function adds an extension for Microsoft Edge using the ExtensionSettings policy: https://learn.microsoft.com/en-us/deployedge/microsoft-edge-manage-extensions-ref-guide. This enables Edge Extensions to be installed and managed like applications, enabling extensions to be pushed to specific devices or users alongside existing GPO/Intune extension policies. This should not be used in conjunction with Edge Management Service which leverages the same registry key to configure Edge extensions.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Add-ADTEdgeExtension",
+    "parameters": [
+      {
+        "name": "ExtensionID",
+        "description": "The ID of the extension to add."
+      },
+      {
+        "name": "UpdateUrl",
+        "description": "The update URL of the extension. This is the URL where the extension will check for updates."
+      },
+      {
+        "name": "InstallationMode",
+        "description": "The installation mode of the extension. Allowed values: blocked, allowed, removed, force_installed, normal_installed."
+      },
+      {
+        "name": "MinimumVersionRequired",
+        "description": "The minimum version of the extension required for installation."
+      }
+    ]
+  },
+  {
+    "name": "Add-ADTModuleCallback",
+    "synopsis": "Adds a callback function to the nominated hooking point.",
+    "description": "This function adds a specified callback function to the nominated hooking point.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Add-ADTModuleCallback",
+    "parameters": [
+      {
+        "name": "Hookpoint",
+        "description": "Where you wish for the callback to be executed at. Valid hookpoints are: * OnInit (The callback is executed before the module is initialized) * OnStart (The callback is executed before the first deployment session is opened) * PreOpen (The callback is executed before a deployment session is opened) * PostOpen (The callback is executed after a deployment session is opened) * PreClose (The callback is executed before the deployment session is closed) * PostClose (The callback is executed after the deployment session is closed) * OnFinish (The callback is executed before the last deployment session is closed) * OnExit (The callback is executed after the last deployment session is closed) Each hook point supports multiple callbacks, each invoked in the order they're added. To see a list all the registered callbacks in order, use `Get-ADTModuleCallback`."
+      },
+      {
+        "name": "Callback",
+        "description": "The callback function to add to the nominated hooking point."
+      }
+    ]
+  },
+  {
+    "name": "Block-ADTAppExecution",
+    "synopsis": "Block the execution of an application(s).",
+    "description": "This function is called when you pass the -BlockExecution parameter to the Stop-RunningApplications function. It does the following: 1) Makes a copy of this script in a temporary directory on the local machine. 2) Checks for an existing scheduled task from previous failed installation attempt where apps were blocked and if found, calls the Unblock-ADTAppExecution function to restore the original IFEO registry keys. This is to prevent the function from overriding the backup of the original IFEO options. 3) Creates a scheduled task to restore the IFEO registry key values in case the script is terminated uncleanly by calling `Unblock-ADTAppExecution` the local temporary copy of this module. 4) Modifies the \"Image File Execution Options\" registry key for the specified process(s) to call `Show-ADTInstallationPrompt` with the appropriate messaging via this module. 5) When the script is called with those parameters, it will display a custom message to the user to indicate that execution of the application has been blocked while the installation is in progress. The text of this message can be customized in the strings.psd1 file.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Block-ADTAppExecution",
+    "parameters": [
+      {
+        "name": "ProcessName",
+        "description": "Name of the process or processes separated by commas."
+      },
+      {
+        "name": "WindowLocation",
+        "description": "The location of the dialog on the screen."
+      }
+    ]
+  },
+  {
+    "name": "Clear-ADTModuleCallback",
+    "synopsis": "Clears the nominated hooking point of all callbacks.",
+    "description": "This function clears the nominated hooking point of all callbacks.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Clear-ADTModuleCallback",
+    "parameters": [
+      {
+        "name": "Hookpoint",
+        "description": "The callback hook point that you wish to clear. Valid hookpoints are: * OnInit (The callback is executed before the module is initialized) * OnStart (The callback is executed before the first deployment session is opened) * PreOpen (The callback is executed before a deployment session is opened) * PostOpen (The callback is executed after a deployment session is opened) * PreClose (The callback is executed before the deployment session is closed) * PostClose (The callback is executed after the deployment session is closed) * OnFinish (The callback is executed before the last deployment session is closed) * OnExit (The callback is executed after the last deployment session is closed) To see a list all the registered callbacks in order, use `Get-ADTModuleCallback`."
+      }
+    ]
+  },
+  {
+    "name": "Close-ADTInstallationProgress",
+    "synopsis": "Closes the dialog created by Show-ADTInstallationProgress.",
+    "description": "Closes the dialog created by Show-ADTInstallationProgress. This function is called by the Close-ADTSession function to close a running instance of the progress dialog if found.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Close-ADTInstallationProgress",
+    "parameters": []
+  },
+  {
+    "name": "Close-ADTSession",
+    "synopsis": "Closes the active ADT session.",
+    "description": "The Close-ADTSession function closes the active ADT session, updates the session's exit code if provided, invokes all registered callbacks, and cleans up the session state. If this is the last session, it flags the module as uninitialized and exits the process with the last exit code.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Close-ADTSession",
+    "parameters": [
+      {
+        "name": "ExitCode",
+        "description": "The exit code to set for the session."
+      },
+      {
+        "name": "NoShellExit",
+        "description": "Doesn't exit PowerShell upon closing of the final session."
+      },
+      {
+        "name": "Force",
+        "description": "Forcibly exits PowerShell upon closing of the final session."
+      },
+      {
+        "name": "PassThru",
+        "description": "Returns the exit code of the session being closed."
+      }
+    ]
+  },
+  {
+    "name": "Complete-ADTFunction",
+    "synopsis": "Completes the execution of an ADT function.",
+    "description": "The Complete-ADTFunction function finalizes the execution of an ADT function by writing a debug log message and restoring the original global verbosity if it was archived off.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Complete-ADTFunction",
+    "parameters": [
+      {
+        "name": "Cmdlet",
+        "description": "The PSCmdlet object representing the cmdlet being completed."
+      }
+    ]
+  },
+  {
+    "name": "Convert-ADTNTAccountToSID",
+    "synopsis": "",
+    "description": "",
+    "link": "",
+    "parameters": []
+  },
+  {
+    "name": "Convert-ADTRegistryPath",
+    "synopsis": "Converts the specified registry key path to a format that is compatible with built-in PowerShell cmdlets.",
+    "description": "Converts the specified registry key path to a format that is compatible with built-in PowerShell cmdlets. Converts registry key hives to their full paths. Example: HKLM is converted to \"Microsoft.PowerShell.Core\\Registry::HKEY_LOCAL_MACHINE\".",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Convert-ADTRegistryPath",
+    "parameters": [
+      {
+        "name": "Key",
+        "description": "Path to the registry key to convert (can be a registry hive or fully qualified path)"
+      },
+      {
+        "name": "Wow6432Node",
+        "description": "Specifies that the 32-bit registry view (Wow6432Node) should be used on a 64-bit system."
+      },
+      {
+        "name": "SID",
+        "description": "The security identifier (SID) for a user. Specifying this parameter will convert a HKEY_CURRENT_USER registry key to the HKEY_USERS\\$SID format. Specify this parameter from the Invoke-ADTAllUsersRegistryAction function to read/edit HKCU registry settings for all users on the system."
+      }
+    ]
+  },
+  {
+    "name": "Convert-ADTSIDToNTAccount",
+    "synopsis": "",
+    "description": "",
+    "link": "",
+    "parameters": []
+  },
+  {
+    "name": "Convert-ADTValuesFromRemainingArguments",
+    "synopsis": "Converts the collected values from a ValueFromRemainingArguments parameter value into a dictionary or PowerShell.exe command line arguments.",
+    "description": "This function converts the collected values from a ValueFromRemainingArguments parameter value into a dictionary or PowerShell.exe command line arguments.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Convert-ADTValuesFromRemainingArguments",
+    "parameters": [
+      {
+        "name": "RemainingArguments",
+        "description": "The collected values to enumerate and process into a dictionary."
+      }
+    ]
+  },
+  {
+    "name": "Convert-ADTValueType",
+    "synopsis": "Casts the provided value to the requested type without range errors.",
+    "description": "This function uses C# code to cast the provided value to the requested type. This avoids errors from PowerShell when values exceed the casted value type's range.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Convert-ADTValueType",
+    "parameters": [
+      {
+        "name": "Value",
+        "description": "The value to convert."
+      },
+      {
+        "name": "To",
+        "description": "What to cast the value to."
+      }
+    ]
+  },
+  {
+    "name": "ConvertTo-ADTNTAccountOrSID",
+    "synopsis": "Convert between NT Account names and their security identifiers (SIDs).",
+    "description": "Specify either the NT Account name or the SID and get the other. Can also convert well known sid types.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/ConvertTo-ADTNTAccountOrSID",
+    "parameters": [
+      {
+        "name": "AccountName",
+        "description": "The Windows NT Account name specified in <domain>\\<username> format. Use fully qualified account names (e.g., <domain>\\<username>) instead of isolated names (e.g, <username>) because they are unambiguous and provide better performance."
+      },
+      {
+        "name": "SID",
+        "description": "The Windows NT Account SID."
+      },
+      {
+        "name": "WellKnownSIDName",
+        "description": "Specify the Well Known SID name translate to the actual SID (e.g., LocalServiceSid). To get all well known SIDs available on system: [Enum]::GetNames([Security.Principal.WellKnownSidType])"
+      },
+      {
+        "name": "WellKnownToNTAccount",
+        "description": "Convert the Well Known SID to an NTAccount name."
+      },
+      {
+        "name": "LocalHost",
+        "description": "Avoids a costly domain check when only converting local accounts."
+      },
+      {
+        "name": "LdapUri",
+        "description": "Allows specification of the LDAP URI to use, either `LDAP://` or `LDAPS://`."
+      }
+    ]
+  },
+  {
+    "name": "Copy-ADTContentToCache",
+    "synopsis": "Copies the toolkit content to a cache folder on the local machine and sets the $adtSession.DirFiles and $adtSession.DirSupportFiles directory to the cache path.",
+    "description": "Copies the toolkit content to a cache folder on the local machine and sets the $adtSession.DirFiles and $adtSession.DirSupportFiles directory to the cache path. This function is useful in environments where an Endpoint Management solution does not provide a managed cache for source files, such as Intune. It is important to clean up the cache in the uninstall section for the current version and potentially also in the pre-installation section for previous versions.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Copy-ADTContentToCache",
+    "parameters": [
+      {
+        "name": "LiteralPath",
+        "description": "The path to the software cache folder."
+      }
+    ]
+  },
+  {
+    "name": "Copy-ADTFile",
+    "synopsis": "Copies files and directories from a source to a destination.",
+    "description": "Copies files and directories from a source to a destination. This function supports recursive copying, overwriting existing files, and returning the copied items.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Copy-ADTFile",
+    "parameters": [
+      {
+        "name": "Path",
+        "description": "Path of the file to copy. Multiple paths can be specified."
+      },
+      {
+        "name": "Destination",
+        "description": "Destination Path of the file to copy."
+      },
+      {
+        "name": "Recurse",
+        "description": "Copy files in subdirectories."
+      },
+      {
+        "name": "Flatten",
+        "description": "Flattens the files into the root destination directory."
+      },
+      {
+        "name": "ContinueFileCopyOnError",
+        "description": "Continue copying files if an error is encountered. This will continue the deployment script and will warn about files that failed to be copied."
+      },
+      {
+        "name": "FileCopyMode",
+        "description": "Select from 'Native' or 'Robocopy'. Default is configured in config.psd1. Note that Robocopy supports * in file names, but not folders, in source paths."
+      },
+      {
+        "name": "RobocopyParams",
+        "description": "Override the default Robocopy parameters."
+      },
+      {
+        "name": "RobocopyAdditionalParams",
+        "description": "Append to the default Robocopy parameters."
+      }
+    ]
+  },
+  {
+    "name": "Copy-ADTFileToUserProfiles",
+    "synopsis": "Copy one or more items to each user profile on the system.",
+    "description": "The Copy-ADTFileToUserProfiles function copies one or more items to each user profile on the system. It supports various options such as recursion, flattening files, and using Robocopy to overcome the 260 character limit.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Copy-ADTFileToUserProfiles",
+    "parameters": [
+      {
+        "name": "Path",
+        "description": "The path of the file or folder to copy."
+      },
+      {
+        "name": "Destination",
+        "description": "The path of the destination folder to append to the root of the user profile."
+      },
+      {
+        "name": "BasePath",
+        "description": "The base path to append the destination folder to."
+      },
+      {
+        "name": "Recurse",
+        "description": "Copy files in subdirectories."
+      },
+      {
+        "name": "Flatten",
+        "description": "Flattens the files into the root destination directory."
+      },
+      {
+        "name": "ContinueFileCopyOnError",
+        "description": "Continue copying files if an error is encountered. This will continue the deployment script and will warn about files that failed to be copied."
+      },
+      {
+        "name": "FileCopyMode",
+        "description": "Select from 'Native' or 'Robocopy'. Default is configured in config.psd1. Note that Robocopy supports * in file names, but not folders, in source paths."
+      },
+      {
+        "name": "RobocopyParams",
+        "description": "Override the default Robocopy parameters."
+      },
+      {
+        "name": "RobocopyAdditionalParams",
+        "description": "Append to the default Robocopy parameters."
+      },
+      {
+        "name": "UserProfiles",
+        "description": "Specifies one or more UserProfile objects to copy files into."
+      },
+      {
+        "name": "ExcludeNTAccount",
+        "description": "Specify NT account names in Domain\\Username format to exclude from the list of user profiles."
+      },
+      {
+        "name": "IncludeSystemProfiles",
+        "description": "Include system profiles: SYSTEM, LOCAL SERVICE, NETWORK SERVICE."
+      },
+      {
+        "name": "IncludeServiceProfiles",
+        "description": "Include service profiles where NTAccount begins with NT SERVICE."
+      },
+      {
+        "name": "ExcludeDefaultUser",
+        "description": "Exclude the Default User."
+      }
+    ]
+  },
+  {
+    "name": "Disable-ADTTerminalServerInstallMode",
+    "synopsis": "Changes the current Remote Desktop Session Host/Citrix server to user execute mode.",
+    "description": "The Disable-ADTTerminalServerInstallMode function changes the current Remote Desktop Session Host/Citrix server to user execute mode. This is useful for ensuring that applications are installed in a way that is compatible with multi-user environments.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Disable-ADTTerminalServerInstallMode",
+    "parameters": []
+  },
+  {
+    "name": "Dismount-ADTWimFile",
+    "synopsis": "Dismounts a WIM file from the specified mount point.",
+    "description": "The Dismount-ADTWimFile function dismounts a WIM file from the specified mount point and discards all changes. This function ensures that the specified path is a valid WIM mount point before attempting to dismount.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Dismount-ADTWimFile",
+    "parameters": [
+      {
+        "name": "ImagePath",
+        "description": "The path to the WIM file."
+      },
+      {
+        "name": "Path",
+        "description": "The path to the WIM mount point."
+      }
+    ]
+  },
+  {
+    "name": "Enable-ADTTerminalServerInstallMode",
+    "synopsis": "Changes the current Remote Desktop Session Host/Citrix server to user install mode.",
+    "description": "The Enable-ADTTerminalServerInstallMode function changes the current Remote Desktop Session Host/Citrix server to user install mode. This is useful for ensuring that applications are installed in a way that is compatible with multi-user environments.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Enable-ADTTerminalServerInstallMode",
+    "parameters": []
+  },
+  {
+    "name": "Expand-ADTConfigValuesInStringTable",
+    "synopsis": "",
+    "description": "",
+    "link": "",
+    "parameters": []
+  },
+  {
+    "name": "Export-ADTEnvironmentTableToSessionState",
+    "synopsis": "Exports the content of `Get-ADTEnvironmentTable` to the provided SessionState as variables.",
+    "description": "This function exports the content of `Get-ADTEnvironmentTable` to the provided SessionState as variables.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Export-ADTEnvironmentTableToSessionState",
+    "parameters": [
+      {
+        "name": "SessionState",
+        "description": "Defaults to $PSCmdlet.SessionState to get the caller's SessionState, so only required if you need to override this."
+      }
+    ]
+  },
+  {
+    "name": "Get-ADTActiveSetupVersion",
+    "synopsis": "",
+    "description": "",
+    "link": "",
+    "parameters": []
+  },
+  {
+    "name": "Get-ADTApplication",
+    "synopsis": "Retrieves information about installed applications.",
+    "description": "Retrieves information about installed applications by querying the registry. You can specify an application name, a product code, or both. Returns information about application publisher, name & version, product code, uninstall string, install source, location, date, and application architecture.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Get-ADTApplication",
+    "parameters": [
+      {
+        "name": "Name",
+        "description": "The name of the application to retrieve information for. Performs a contains match on the application display name by default."
+      },
+      {
+        "name": "NameMatch",
+        "description": "Specifies the type of match to perform on the application name. Valid values are 'Contains', 'Exact', 'Wildcard', and 'Regex'. The default value is 'Contains'."
+      },
+      {
+        "name": "ProductCode",
+        "description": "The product code of the application to retrieve information for."
+      },
+      {
+        "name": "ApplicationType",
+        "description": "Specifies the type of application to remove. Valid values are 'All', 'MSI', and 'EXE'. The default value is 'All'."
+      },
+      {
+        "name": "IncludeUpdatesAndHotfixes",
+        "description": "Include matches against updates and hotfixes in results."
+      },
+      {
+        "name": "FilterScript",
+        "description": "A script used to filter the results as they're processed."
+      }
+    ]
+  },
+  {
+    "name": "Get-ADTBoundParametersAndDefaultValues",
+    "synopsis": "Returns a hashtable with the output of $PSBoundParameters and default-valued parameters for the given InvocationInfo.",
+    "description": "This function processes the provided InvocationInfo and combines the results of $PSBoundParameters and default-valued parameters via the InvocationInfo's ScriptBlock AST (Abstract Syntax Tree).",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Get-ADTBoundParametersAndDefaultValues",
+    "parameters": [
+      {
+        "name": "Invocation",
+        "description": "The script or function's InvocationInfo ($MyInvocation) to process."
+      },
+      {
+        "name": "ParameterSetName",
+        "description": "The ParameterSetName to use as a filter against the Invocation's parameters."
+      },
+      {
+        "name": "HelpMessage",
+        "description": "The HelpMessage field to use as a filter against the Invocation's parameters."
+      },
+      {
+        "name": "Exclude",
+        "description": "One or more parameter names to exclude from the results."
+      },
+      {
+        "name": "CommonParameters",
+        "description": "Specifies whether PowerShell advanced function common parameters should be included."
+      }
+    ]
+  },
+  {
+    "name": "Get-ADTCommandTable",
+    "synopsis": "Returns PSAppDeployToolkit's safe command lookup table.",
+    "description": "This function returns PSAppDeployToolkit's safe command lookup table, which can be used for command lookups within extending modules. Please note that PSAppDeployToolkit's safe command table only has commands in it that are used within this module, and not necessarily all commands offered by PowerShell and its built-in modules out of the box.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Get-ADTCommandTable",
+    "parameters": []
+  },
+  {
+    "name": "Get-ADTConfig",
+    "synopsis": "Retrieves the configuration data for the ADT module.",
+    "description": "The Get-ADTConfig function retrieves the configuration data for the ADT module. This function ensures that the ADT module has been initialized before attempting to retrieve the configuration data. If the module is not initialized, it throws an error.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Get-ADTConfig",
+    "parameters": []
+  },
+  {
+    "name": "Get-ADTDeferHistory",
+    "synopsis": "Get the history of deferrals in the registry for the current application.",
+    "description": "Get the history of deferrals in the registry for the current application.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Get-ADTDeferHistory",
+    "parameters": []
+  },
+  {
+    "name": "Get-ADTEnvironment",
+    "synopsis": "Retrieves the environment data for the ADT module. This function has been replaced by [Get-ADTEnvironmentTable]. Please migrate your scripts as this will be removed in PSAppDeployToolkit 4.2.0.",
+    "description": "The Get-ADTEnvironment function retrieves the environment data for the ADT module. This function ensures that the ADT module has been initialized before attempting to retrieve the environment data. If the module is not initialized, it throws an error. This function has been replaced by [Get-ADTEnvironmentTable]. Please migrate your scripts as this will be removed in PSAppDeployToolkit 4.2.0.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Get-ADTEnvironment",
+    "parameters": []
+  },
+  {
+    "name": "Get-ADTEnvironmentTable",
+    "synopsis": "Retrieves the environment data for the ADT module.",
+    "description": "The Get-ADTEnvironmentTable function retrieves the environment data for the ADT module. This function ensures that the ADT module has been initialized before attempting to retrieve the environment data. If the module is not initialized, it throws an error.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Get-ADTEnvironmentTable",
+    "parameters": []
+  },
+  {
+    "name": "Get-ADTEnvironmentVariable",
+    "synopsis": "Gets the value of the specified environment variable.",
+    "description": "This function gets the value of the specified environment variable.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Get-ADTEnvironmentVariable",
+    "parameters": [
+      {
+        "name": "Variable",
+        "description": "The variable to get."
+      },
+      {
+        "name": "Target",
+        "description": "The target of the variable to get. This can be the machine, user, or process."
+      }
+    ]
+  },
+  {
+    "name": "Get-ADTExecutableInfo",
+    "synopsis": "Retrieves information about any valid Windows PE executable.",
+    "description": "This function retrieves information about any valid Windows PE executable, such as version, bitness, and other characteristics.",
+    "link": "https://psappdeploytoolkit.com",
+    "parameters": [
+      {
+        "name": "Path",
+        "description": "One or more expandable executable paths to retrieve info from."
+      },
+      {
+        "name": "LiteralPath",
+        "description": "One or more literal executable paths to retrieve info from."
+      },
+      {
+        "name": "InputObject",
+        "description": "A FileInfo object to retrieve executable info from. Available for pipelining."
+      }
+    ]
+  },
+  {
+    "name": "Get-ADTFileVersion",
+    "synopsis": "Gets the version of the specified file.",
+    "description": "The Get-ADTFileVersion function retrieves the version information of the specified file. By default, it returns the FileVersion, but it can also return the ProductVersion if the -ProductVersion switch is specified.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Get-ADTFileVersion",
+    "parameters": [
+      {
+        "name": "File",
+        "description": "The path of the file."
+      },
+      {
+        "name": "ProductVersion",
+        "description": "Switch that makes the command return the file's ProductVersion instead of its FileVersion."
+      }
+    ]
+  },
+  {
+    "name": "Get-ADTFreeDiskSpace",
+    "synopsis": "Retrieves the free disk space in MB on a particular drive (defaults to system drive).",
+    "description": "The Get-ADTFreeDiskSpace function retrieves the free disk space in MB on a specified drive. If no drive is specified, it defaults to the system drive. This function is useful for monitoring disk space availability.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Get-ADTFreeDiskSpace",
+    "parameters": [
+      {
+        "name": "Drive",
+        "description": "The drive to check free disk space on."
+      }
+    ]
+  },
+  {
+    "name": "Get-ADTIniSection",
+    "synopsis": "Parses an INI file and returns the specified section as an ordered hashtable of key value pairs.",
+    "description": "Parses an INI file and returns the specified section as an ordered hashtable of key value pairs.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Get-ADTIniValue",
+    "parameters": [
+      {
+        "name": "FilePath",
+        "description": "Path to the INI file."
+      },
+      {
+        "name": "Section",
+        "description": "Section within the INI file."
+      }
+    ]
+  },
+  {
+    "name": "Get-ADTIniValue",
+    "synopsis": "Parses an INI file and returns the value of the specified section and key.",
+    "description": "The Get-ADTIniValue function parses an INI file and returns the value of the specified section and key.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Get-ADTIniValue",
+    "parameters": [
+      {
+        "name": "FilePath",
+        "description": "Path to the INI file."
+      },
+      {
+        "name": "Section",
+        "description": "Section within the INI file."
+      },
+      {
+        "name": "Key",
+        "description": "Key within the section of the INI file."
+      }
+    ]
+  },
+  {
+    "name": "Get-ADTLoggedOnUser",
+    "synopsis": "Retrieves session details for all local and RDP logged on users.",
+    "description": "The Get-ADTLoggedOnUser function retrieves session details for all local and RDP logged on users using Win32 APIs. It provides information such as NTAccount, SID, UserName, DomainName, SessionId, SessionName, ConnectState, IsCurrentSession, IsConsoleSession, IsUserSession, IsActiveUserSession, IsRdpSession, IsLocalAdmin, LogonTime, IdleTime, DisconnectTime, ClientName, ClientProtocolType, ClientDirectory, and ClientBuildNumber.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Get-ADTLoggedOnUser",
+    "parameters": []
+  },
+  {
+    "name": "Get-ADTModuleCallback",
+    "synopsis": "Returns all callbacks from the nominated hooking point.",
+    "description": "This function returns all callbacks from the nominated hooking point.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Get-ADTModuleCallback",
+    "parameters": [
+      {
+        "name": "Hookpoint",
+        "description": "The hook point to return the callbacks for. Valid hookpoints are: * OnInit (The callback is executed before the module is initialized) * OnStart (The callback is executed before the first deployment session is opened) * PreOpen (The callback is executed before a deployment session is opened) * PostOpen (The callback is executed after a deployment session is opened) * PreClose (The callback is executed before the deployment session is closed) * PostClose (The callback is executed after the deployment session is closed) * OnFinish (The callback is executed before the last deployment session is closed) * OnExit (The callback is executed after the last deployment session is closed)"
+      }
+    ]
+  },
+  {
+    "name": "Get-ADTMsiExitCodeMessage",
+    "synopsis": "Get message for MSI exit code.",
+    "description": "Get message for MSI exit code by reading it from msimsg.dll.",
+    "link": "http://msdn.microsoft.com/en-us/library/aa368542(v=vs.85).aspx",
+    "parameters": [
+      {
+        "name": "MsiExitCode",
+        "description": "MSI exit code."
+      }
+    ]
+  },
+  {
+    "name": "Get-ADTMsiTableProperty",
+    "synopsis": "Get all of the properties from a Windows Installer database table or the Summary Information stream and return as a custom object.",
+    "description": "Use the Windows Installer object to read all of the properties from a Windows Installer database table or the Summary Information stream.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Get-ADTMsiTableProperty",
+    "parameters": [
+      {
+        "name": "LiteralPath",
+        "description": "The fully qualified path to an database file. Supports .msi and .msp files."
+      },
+      {
+        "name": "TransformPath",
+        "description": "The fully qualified path to a list of MST file(s) which should be applied to the MSI file."
+      },
+      {
+        "name": "Table",
+        "description": "The name of the the MSI table from which all of the properties must be retrieved."
+      },
+      {
+        "name": "TablePropertyNameColumnNum",
+        "description": "Specify the table column number which contains the name of the properties."
+      },
+      {
+        "name": "TablePropertyValueColumnNum",
+        "description": "Specify the table column number which contains the value of the properties."
+      },
+      {
+        "name": "GetSummaryInformation",
+        "description": "Retrieves the Summary Information for the Windows Installer database. Summary Information property descriptions: https://msdn.microsoft.com/en-us/library/aa372049(v=vs.85).aspx"
+      }
+    ]
+  },
+  {
+    "name": "Get-ADTObjectProperty",
+    "synopsis": "Get a property from any object.",
+    "description": "Get a property from any object.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Get-ADTObjectProperty",
+    "parameters": [
+      {
+        "name": "InputObject",
+        "description": "Specifies an object which has properties that can be retrieved."
+      },
+      {
+        "name": "PropertyName",
+        "description": "Specifies the name of a property to retrieve."
+      },
+      {
+        "name": "ArgumentList",
+        "description": "Argument to pass to the property being retrieved."
+      }
+    ]
+  },
+  {
+    "name": "Get-ADTOperatingSystemInfo",
+    "synopsis": "Gets information about the current computer's operating system.",
+    "description": "Gets information about the current computer's operating system, such as name, version, edition, and other information.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Get-ADTOperatingSystemInfo",
+    "parameters": []
+  },
+  {
+    "name": "Get-ADTPEFileArchitecture",
+    "synopsis": "Determine if a PE file is a 32-bit or a 64-bit file.",
+    "description": "Determine if a PE file is a 32-bit or a 64-bit file by examining the file's image file header. PE file extensions: .exe, .dll, .ocx, .drv, .sys, .scr, .efi, .cpl, .fon",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Get-ADTPEFileArchitecture",
+    "parameters": [
+      {
+        "name": "Path",
+        "description": "One or more expandable executable paths to retrieve info from."
+      },
+      {
+        "name": "LiteralPath",
+        "description": "One or more literal executable paths to retrieve info from."
+      },
+      {
+        "name": "InputObject",
+        "description": "A FileInfo object to retrieve executable info from. Available for pipelining."
+      },
+      {
+        "name": "PassThru",
+        "description": "Get the file object, attach a property indicating the file binary type, and write to pipeline."
+      }
+    ]
+  },
+  {
+    "name": "Get-ADTPendingReboot",
+    "synopsis": "Get the pending reboot status on a local computer.",
+    "description": "Check WMI and the registry to determine if the system has a pending reboot operation from any of the following: - Component Based Servicing (Vista, Windows 2008) - Windows Update / Auto Update (XP, Windows 2003 / 2008) - SCCM 2012 Clients (DetermineIfRebootPending WMI method) - App-V Pending Tasks (global based Appv 5.0 SP2) - Pending File Rename Operations (XP, Windows 2003 / 2008)",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Get-ADTPendingReboot",
+    "parameters": []
+  },
+  {
+    "name": "Get-ADTPowerShellProcessPath",
+    "synopsis": "Retrieves the path to the PowerShell executable.",
+    "description": "The Get-ADTPowerShellProcessPath function returns the path to the PowerShell executable. It determines whether the current PowerShell session is running in Windows PowerShell or PowerShell Core and returns the appropriate executable path.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Get-ADTPowerShellProcessPath",
+    "parameters": []
+  },
+  {
+    "name": "Get-ADTPresentationSettingsEnabledUsers",
+    "synopsis": "Tests whether any users have presentation mode enabled on their device.",
+    "description": "Tests whether any users have presentation mode enabled on their device. This can be enabled via the PC's Mobility Settings, or with PresentationSettings.exe.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Get-ADTPresentationSettingsEnabledUsers",
+    "parameters": []
+  },
+  {
+    "name": "Get-ADTRegistryKey",
+    "synopsis": "Retrieves value names and value data for a specified registry key or optionally, a specific value.",
+    "description": "Retrieves value names and value data for a specified registry key or optionally, a specific value. If the registry key does not exist or contain any values, the function will return $null by default. To test for existence of a registry key path, use built-in Test-Path cmdlet.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Get-ADTRegistryKey",
+    "parameters": [
+      {
+        "name": "Path",
+        "description": "Path of the registry key, wildcards permitted."
+      },
+      {
+        "name": "LiteralPath",
+        "description": "Literal path of the registry key."
+      },
+      {
+        "name": "Name",
+        "description": "Value name to retrieve (optional)."
+      },
+      {
+        "name": "Wow6432Node",
+        "description": "Specify this switch to read the 32-bit registry (Wow6432Node) on 64-bit systems."
+      },
+      {
+        "name": "SID",
+        "description": "The security identifier (SID) for a user. Specifying this parameter will convert a HKEY_CURRENT_USER registry key to the HKEY_USERS\\$SID format. Specify this parameter from the Invoke-ADTAllUsersRegistryAction function to read/edit HKCU registry settings for all users on the system."
+      },
+      {
+        "name": "ReturnEmptyKeyIfExists",
+        "description": "Return the registry key if it exists but it has no property/value pairs underneath it."
+      },
+      {
+        "name": "DoNotExpandEnvironmentNames",
+        "description": "Return unexpanded REG_EXPAND_SZ values."
+      }
+    ]
+  },
+  {
+    "name": "Get-ADTRunningProcesses",
+    "synopsis": "Gets the processes that are running from a list of process objects.",
+    "description": "Gets the processes that are running from a list of process objects.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Get-ADTServiceStartMode",
+    "parameters": [
+      {
+        "name": "ProcessObjects",
+        "description": "One or more process objects to search for."
+      }
+    ]
+  },
+  {
+    "name": "Get-ADTServiceStartMode",
+    "synopsis": "Retrieves the startup mode of a specified service.",
+    "description": "Retrieves the startup mode of a specified service. This function checks the service's start type and adjusts the result if the service is set to 'Automatic (Delayed Start)'.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Get-ADTServiceStartMode",
+    "parameters": [
+      {
+        "name": "Service",
+        "description": "Specify the service object to retrieve the startup mode for."
+      }
+    ]
+  },
+  {
+    "name": "Get-ADTSession",
+    "synopsis": "Retrieves the most recent ADT session.",
+    "description": "The Get-ADTSession function returns the most recent session from the ADT module data. If no sessions are found, it throws an error indicating that an ADT session should be opened using Open-ADTSession before calling this function.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Get-ADTSession",
+    "parameters": []
+  },
+  {
+    "name": "Get-ADTShortcut",
+    "synopsis": "Get information from a .lnk or .url type shortcut.",
+    "description": "Get information from a .lnk or .url type shortcut. Returns a hashtable with details about the shortcut such as TargetPath, Arguments, Description, and more.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Get-ADTShortcut",
+    "parameters": [
+      {
+        "name": "LiteralPath",
+        "description": "Path to the shortcut to get information from."
+      }
+    ]
+  },
+  {
+    "name": "Get-ADTStringTable",
+    "synopsis": "Retrieves the string database from the ADT module.",
+    "description": "The Get-ADTStringTable function returns the string database if it has been initialized. If the string database is not initialized, it throws an error indicating that Initialize-ADTModule should be called before using this function.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Get-ADTStringTable",
+    "parameters": []
+  },
+  {
+    "name": "Get-ADTUniversalDate",
+    "synopsis": "Returns the date/time for the local culture in a universal sortable date time pattern. This function has been deprecated and will be removed from PSAppDeployToolkit 4.2.0.",
+    "description": "Converts the current datetime or a datetime string for the current culture into a universal sortable date time pattern, e.g. 2013-08-22 11:51:52Z.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Get-ADTUniversalDate",
+    "parameters": [
+      {
+        "name": "DateTime",
+        "description": "Specify the DateTime in the current culture."
+      }
+    ]
+  },
+  {
+    "name": "Get-ADTUserNotificationState",
+    "synopsis": "Gets the specified user's notification state.",
+    "description": "This function gets the specified user's notification state.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Get-ADTUserNotificationState",
+    "parameters": []
+  },
+  {
+    "name": "Get-ADTUserProfiles",
+    "synopsis": "Get the User Profile Path, User Account SID, and the User Account Name for all users that log onto the machine and also the Default User.",
+    "description": "Get the User Profile Path, User Account SID, and the User Account Name for all users that log onto the machine and also the Default User (which does not log on). Please note that the NTAccount property may be empty for some user profiles but the SID and ProfilePath properties will always be populated.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Get-ADTUserProfiles",
+    "parameters": [
+      {
+        "name": "FilterScript",
+        "description": "Allows filtration of the returned result by any property in a UserProfile object."
+      },
+      {
+        "name": "ExcludeNTAccount",
+        "description": "Specify NT account names in DOMAIN\\username format to exclude from the list of user profiles."
+      },
+      {
+        "name": "IncludeSystemProfiles",
+        "description": "Include system profiles: SYSTEM, LOCAL SERVICE, NETWORK SERVICE."
+      },
+      {
+        "name": "IncludeServiceProfiles",
+        "description": "Include service (NT SERVICE) profiles."
+      },
+      {
+        "name": "IncludeIISAppPoolProfiles",
+        "description": "Include IIS AppPool profiles. Excluded by default as they don't parse well."
+      },
+      {
+        "name": "ExcludeDefaultUser",
+        "description": "Exclude the Default User."
+      },
+      {
+        "name": "LoadProfilePaths",
+        "description": "Load additional profile paths for each user profile."
+      }
+    ]
+  },
+  {
+    "name": "Get-ADTWindowTitle",
+    "synopsis": "Search for an open window title and return details about the window.",
+    "description": "Search for a window title. If window title searched for returns more than one result, then details for each window will be displayed. Returns the following properties for each window: - WindowTitle - WindowHandle - ParentProcess - ParentProcessMainWindowHandle - ParentProcessId Function does not work in SYSTEM context unless launched with \"psexec.exe -s -i\" to run it as an interactive process under the SYSTEM account.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Get-ADTWindowTitle",
+    "parameters": [
+      {
+        "name": "WindowTitle",
+        "description": "One or more titles of the application window to search for using regex matching."
+      },
+      {
+        "name": "WindowHandle",
+        "description": "One or more window handles of the application window to search for."
+      },
+      {
+        "name": "ParentProcess",
+        "description": "One or more process names of the application window to search for."
+      }
+    ]
+  },
+  {
+    "name": "Initialize-ADTFunction",
+    "synopsis": "Initializes the ADT function environment.",
+    "description": "Initializes the ADT function environment by setting up necessary variables and logging function start details. It ensures that the function always stops on errors and handles verbose logging.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Initialize-ADTFunction",
+    "parameters": [
+      {
+        "name": "Cmdlet",
+        "description": "The cmdlet that is being initialized."
+      },
+      {
+        "name": "SessionState",
+        "description": "The session state of the cmdlet."
+      }
+    ]
+  },
+  {
+    "name": "Initialize-ADTModule",
+    "synopsis": "Initializes the ADT module by setting up necessary configurations and environment.",
+    "description": "The Initialize-ADTModule function sets up the environment for the ADT module by initializing necessary variables, configurations, and string tables. It ensures that the module is not initialized while there is an active ADT session in progress. This function prepares the module for use by clearing callbacks, sessions, and setting up the environment table.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Initialize-ADTModule",
+    "parameters": [
+      {
+        "name": "ScriptDirectory",
+        "description": "An override directory to use for config and string loading."
+      },
+      {
+        "name": "AdditionalEnvironmentVariables",
+        "description": "A dictionary of key/value pairs to inject into the generated environment table."
+      }
+    ]
+  },
+  {
+    "name": "Install-ADTMSUpdates",
+    "synopsis": "Install all Microsoft Updates in a given directory. This function has been deprecated and will be removed from PSAppDeployToolkit 4.2.0.",
+    "description": "Install all Microsoft Updates of type \".exe\", \".msu\", or \".msp\" in a given directory (recursively search directory). The function will check if the update is already installed and skip it if it is. It handles older redistributables and different types of updates appropriately.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Install-ADTMSUpdates",
+    "parameters": [
+      {
+        "name": "Directory",
+        "description": "Directory containing the updates."
+      }
+    ]
+  },
+  {
+    "name": "Install-ADTSCCMSoftwareUpdates",
+    "synopsis": "Scans for outstanding SCCM updates to be installed and installs the pending updates.",
+    "description": "Scans for outstanding SCCM updates to be installed and installs the pending updates. Only compatible with SCCM 2012 Client or higher. This function can take several minutes to run.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Install-ADTSCCMSoftwareUpdates",
+    "parameters": [
+      {
+        "name": "SoftwareUpdatesScanWaitInSeconds",
+        "description": "The amount of time to wait in seconds for the software updates scan to complete."
+      },
+      {
+        "name": "WaitForPendingUpdatesTimeout",
+        "description": "The amount of time to wait for missing and pending updates to install before exiting the function."
+      }
+    ]
+  },
+  {
+    "name": "Invoke-ADTAllUsersRegistryAction",
+    "synopsis": "Set current user registry settings for all current users and any new users in the future.",
+    "description": "Set HKCU registry settings for all current and future users by loading their NTUSER.dat registry hive file, and making the modifications. This function will modify HKCU settings for all users even when executed under the SYSTEM account and can be used as an alternative to using ActiveSetup for registry settings. To ensure new users in the future get the registry edits, the Default User registry hive used to provision the registry for new users is modified. The advantage of using this function over ActiveSetup is that a user does not have to log off and log back on before the changes take effect.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Invoke-ADTAllUsersRegistryAction",
+    "parameters": [
+      {
+        "name": "ScriptBlock",
+        "description": "Script block which contains HKCU registry actions to be run for all users on the system."
+      },
+      {
+        "name": "UserProfiles",
+        "description": "Specify the user profiles to modify HKCU registry settings for. Default is all user profiles except for system profiles."
+      },
+      {
+        "name": "SkipUnloadedProfiles",
+        "description": "Specifies that unloaded registry hives should be skipped and not be loaded by the function."
+      }
+    ]
+  },
+  {
+    "name": "Invoke-ADTCommandWithRetries",
+    "synopsis": "Drop-in replacement for any cmdlet/function where a retry is desirable due to transient issues.",
+    "description": "This function invokes the specified cmdlet/function, accepting all of its parameters but retries an operation for the configured value before throwing.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Invoke-ADTCommandWithRetries",
+    "parameters": [
+      {
+        "name": "Command",
+        "description": "The name of the command to invoke."
+      },
+      {
+        "name": "Retries",
+        "description": "How many retries to perform before throwing."
+      },
+      {
+        "name": "SleepDuration",
+        "description": "How long to sleep between retries."
+      },
+      {
+        "name": "MaximumElapsedTime",
+        "description": "The maximum elapsed time allowed to passed while attempting retries. If the maximum elapsted time has passed and there are still attempts remaining they will be disgarded. If this parameter is supplied and the `-Retries` parameter isn't, this command will continue to retry the provided command until the time limit runs out."
+      },
+      {
+        "name": "SleepSeconds",
+        "description": "This parameter is obsolete and will be removed in PSAppDeployToolkit 4.2.0. Please use `-SleepDuration` instead."
+      },
+      {
+        "name": "Parameters",
+        "description": "A 'ValueFromRemainingArguments' parameter to collect the parameters as would be passed to the provided Command. While values can be directly provided to this parameter, it's not designed to be explicitly called."
+      }
+    ]
+  },
+  {
+    "name": "Invoke-ADTDependentServiceOperation",
+    "synopsis": "",
+    "description": "",
+    "link": "",
+    "parameters": []
+  },
+  {
+    "name": "Invoke-ADTFunctionErrorHandler",
+    "synopsis": "Handles errors within ADT functions by logging and optionally passing through the error.",
+    "description": "This function handles errors within ADT functions by logging the error message and optionally passing through the error record. It recovers the true ErrorActionPreference set by the caller and sets it within the function. If a log message is provided, it appends the resolved error record to the log message. Depending on the ErrorActionPreference, it either throws a terminating error or writes a non-terminating error.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Invoke-ADTFunctionErrorHandler",
+    "parameters": [
+      {
+        "name": "Cmdlet",
+        "description": "The cmdlet that is calling this function."
+      },
+      {
+        "name": "SessionState",
+        "description": "The session state of the calling cmdlet."
+      },
+      {
+        "name": "ErrorRecord",
+        "description": "The error record to handle."
+      },
+      {
+        "name": "LogMessage",
+        "description": "The error message to write to the active ADTSession's log file."
+      },
+      {
+        "name": "ResolveErrorProperties",
+        "description": "If specified, the specific ErrorRecord properties to print during resolution."
+      },
+      {
+        "name": "AdditionalResolveErrorProperties",
+        "description": "If specified, a list of additional ErrorRecord properties to print during resolution."
+      },
+      {
+        "name": "DisableErrorResolving",
+        "description": "If specified, the function will not append the resolved error record to the log message."
+      },
+      {
+        "name": "Silent",
+        "description": "If specified, doesn't write anything to the log and just handles the ErrorRecord itself."
+      }
+    ]
+  },
+  {
+    "name": "Invoke-ADTObjectMethod",
+    "synopsis": "Invoke method on any object.",
+    "description": "Invoke method on any object with or without using named parameters.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Invoke-ADTObjectMethod",
+    "parameters": [
+      {
+        "name": "InputObject",
+        "description": "Specifies an object which has methods that can be invoked."
+      },
+      {
+        "name": "MethodName",
+        "description": "Specifies the name of a method to invoke."
+      },
+      {
+        "name": "ArgumentList",
+        "description": "Argument to pass to the method being executed. Allows execution of method without specifying named parameters."
+      },
+      {
+        "name": "Parameter",
+        "description": "Argument to pass to the method being executed. Allows execution of method by using named parameters."
+      }
+    ]
+  },
+  {
+    "name": "Invoke-ADTRegSvr32",
+    "synopsis": "Register or unregister a DLL file.",
+    "description": "Register or unregister a DLL file using regsvr32.exe. This function determines the bitness of the DLL file and uses the appropriate version of regsvr32.exe to perform the action. It supports both 32-bit and 64-bit DLL files on corresponding operating systems.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Invoke-ADTRegSvr32",
+    "parameters": [
+      {
+        "name": "FilePath",
+        "description": "Path to the DLL file."
+      },
+      {
+        "name": "Action",
+        "description": "Specify whether to register or unregister the DLL."
+      }
+    ]
+  },
+  {
+    "name": "Invoke-ADTSCCMTask",
+    "synopsis": "Triggers SCCM to invoke the requested schedule task ID.",
+    "description": "Triggers SCCM to invoke the requested schedule task ID. This function supports a variety of Schedule Id values as defined via https://learn.microsoft.com/en-us/intune/configmgr/develop/reference/core/clients/client-classes/triggerschedule-method-in-class-sms_client.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Invoke-ADTSCCMTask",
+    "parameters": [
+      {
+        "name": "ScheduleId",
+        "description": "Name of the Schedule Id to trigger."
+      }
+    ]
+  },
+  {
+    "name": "Mount-ADTWimFile",
+    "synopsis": "Mounts a WIM file to a specified directory.",
+    "description": "Mounts a WIM file to a specified directory. The function supports mounting by image index or image name. It also provides options to forcefully remove existing directories and return the mounted image details.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Mount-ADTWimFile",
+    "parameters": [
+      {
+        "name": "ImagePath",
+        "description": "Path to the WIM file to be mounted."
+      },
+      {
+        "name": "Path",
+        "description": "Directory where the WIM file will be mounted. The directory either must not exist, or must be empty and not have a pre-existing WIM mounted."
+      },
+      {
+        "name": "Index",
+        "description": "Index of the image within the WIM file to be mounted."
+      },
+      {
+        "name": "Name",
+        "description": "Name of the image within the WIM file to be mounted."
+      },
+      {
+        "name": "Force",
+        "description": "Forces the removal of the existing directory if it is not empty."
+      },
+      {
+        "name": "PassThru",
+        "description": "If specified, the function will return the results from `Mount-WindowsImage`."
+      }
+    ]
+  },
+  {
+    "name": "New-ADTErrorRecord",
+    "synopsis": "Creates a new ErrorRecord object.",
+    "description": "This function creates a new ErrorRecord object with the specified exception, error category, and optional parameters. It allows for detailed error information to be captured and returned to the caller, who can then throw the error.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/New-ADTErrorRecord",
+    "parameters": [
+      {
+        "name": "Exception",
+        "description": "The exception object that caused the error."
+      },
+      {
+        "name": "Category",
+        "description": "The category of the error."
+      },
+      {
+        "name": "ErrorId",
+        "description": "The identifier for the error. Default is 'NotSpecified'."
+      },
+      {
+        "name": "TargetObject",
+        "description": "The target object that the error is related to."
+      },
+      {
+        "name": "TargetName",
+        "description": "The name of the target that the error is related to."
+      },
+      {
+        "name": "TargetType",
+        "description": "The type of the target that the error is related to."
+      },
+      {
+        "name": "Activity",
+        "description": "The activity that was being performed when the error occurred."
+      },
+      {
+        "name": "Reason",
+        "description": "The reason for the error."
+      },
+      {
+        "name": "RecommendedAction",
+        "description": "The recommended action to resolve the error."
+      }
+    ]
+  },
+  {
+    "name": "New-ADTFolder",
+    "synopsis": "Create a new folder.",
+    "description": "Create a new folder if it does not exist. This function checks if the specified path already exists and creates the folder if it does not. It logs the creation process and handles any errors that may occur during the folder creation.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/New-ADTFolder",
+    "parameters": [
+      {
+        "name": "LiteralPath",
+        "description": "Path to the new folder to create."
+      }
+    ]
+  },
+  {
+    "name": "New-ADTMsiTransform",
+    "synopsis": "Create a transform file for an MSI database.",
+    "description": "Create a transform file for an MSI database and create/modify properties in the Properties table. This function allows you to specify an existing transform to apply before making changes and to define the path for the new transform file. If the new transform file already exists, it will be deleted before creating a new one.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/New-ADTMsiTransform",
+    "parameters": [
+      {
+        "name": "MsiPath",
+        "description": "Specify the path to an MSI file."
+      },
+      {
+        "name": "ApplyTransformPath",
+        "description": "Specify the path to a transform which should be applied to the MSI database before any new properties are created or modified."
+      },
+      {
+        "name": "NewTransformPath",
+        "description": "Specify the path where the new transform file with the desired properties will be created. If a transform file of the same name already exists, it will be deleted before a new one is created."
+      },
+      {
+        "name": "TransformProperties",
+        "description": "Hashtable which contains calls to `Set-ADTMsiProperty` for configuring the desired properties which should be included in the new transform file. Example hashtable: `@{ ALLUSERS = 1 }`"
+      }
+    ]
+  },
+  {
+    "name": "New-ADTShortcut",
+    "synopsis": "Creates a new .lnk or .url type shortcut.",
+    "description": "Creates a new shortcut .lnk or .url file, with configurable options. This function allows you to specify various parameters such as the target path, arguments, icon location, description, working directory, window style, run as administrator, and hotkey.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/New-ADTShortcut",
+    "parameters": [
+      {
+        "name": "LiteralPath",
+        "description": "Path to save the shortcut."
+      },
+      {
+        "name": "TargetPath",
+        "description": "Target path or URL that the shortcut launches."
+      },
+      {
+        "name": "Arguments",
+        "description": "Arguments to be passed to the target path."
+      },
+      {
+        "name": "IconLocation",
+        "description": "Location of the icon used for the shortcut."
+      },
+      {
+        "name": "IconIndex",
+        "description": "The index of the icon. Executables, DLLs, ICO files with multiple icons need the icon index to be specified. This parameter is an Integer. The first index is 0."
+      },
+      {
+        "name": "Description",
+        "description": "Description of the shortcut."
+      },
+      {
+        "name": "WorkingDirectory",
+        "description": "Working Directory to be used for the target path."
+      },
+      {
+        "name": "WindowStyle",
+        "description": "Windows style of the application. Options: Normal, Maximized, Minimized."
+      },
+      {
+        "name": "RunAsAdmin",
+        "description": "Set shortcut to run program as administrator. This option will prompt user to elevate when executing shortcut."
+      },
+      {
+        "name": "Hotkey",
+        "description": "Create a Hotkey to launch the shortcut, e.g. \"CTRL+SHIFT+F\"."
+      }
+    ]
+  },
+  {
+    "name": "New-ADTTemplate",
+    "synopsis": "Creates a new folder containing a template front end and module folder, ready to customise.",
+    "description": "Specify a destination path where a new folder will be created. You also have the option of creating a template for v3 compatibility mode.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/New-ADTTemplate",
+    "parameters": [
+      {
+        "name": "Destination",
+        "description": "Path where the new folder should be created. Default is the current working directory."
+      },
+      {
+        "name": "Name",
+        "description": "Name of the newly created folder. Default is PSAppDeployToolkit_Version."
+      },
+      {
+        "name": "Version",
+        "description": "Defaults to 4 for the standard v4 template. Use 3 for the v3 compatibility mode template."
+      },
+      {
+        "name": "Show",
+        "description": "Opens the newly created folder in Windows Explorer."
+      },
+      {
+        "name": "Force",
+        "description": "If the destination folder already exists, this switch will force the creation of the new folder."
+      },
+      {
+        "name": "PassThru",
+        "description": "Returns the newly created folder object."
+      }
+    ]
+  },
+  {
+    "name": "New-ADTValidateScriptErrorRecord",
+    "synopsis": "Creates a new ErrorRecord for script validation errors.",
+    "description": "This function creates a new ErrorRecord object for script validation errors. It takes the parameter name, provided value, exception message, and an optional inner exception to build a detailed error record. This helps in identifying and handling invalid parameter values in scripts.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/New-ADTValidateScriptErrorRecord",
+    "parameters": [
+      {
+        "name": "ParameterName",
+        "description": "The name of the parameter that caused the validation error."
+      },
+      {
+        "name": "ProvidedValue",
+        "description": "The value provided for the parameter that caused the validation error."
+      },
+      {
+        "name": "ExceptionMessage",
+        "description": "The message describing the validation error."
+      },
+      {
+        "name": "InnerException",
+        "description": "An optional inner exception that provides more details about the validation error."
+      }
+    ]
+  },
+  {
+    "name": "New-ADTZipFile",
+    "synopsis": "Create a new zip archive or add content to an existing archive.",
+    "description": "Create a new zip archive or add content to an existing archive by using PowerShell's Compress-Archive.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/New-ADTZipFile",
+    "parameters": [
+      {
+        "name": "Path",
+        "description": "One or more paths to compress. Supports wildcards."
+      },
+      {
+        "name": "LiteralPath",
+        "description": "One or more literal paths to compress."
+      },
+      {
+        "name": "DestinationPath",
+        "description": "The file path for where the zip file should be created."
+      },
+      {
+        "name": "CompressionLevel",
+        "description": "The level of compression to apply to the zip file."
+      },
+      {
+        "name": "Update",
+        "description": "Specifies whether to update an existing zip file or not."
+      },
+      {
+        "name": "Force",
+        "description": "Specifies whether an existing zip file should be overwritten."
+      },
+      {
+        "name": "RemoveSourceAfterArchiving",
+        "description": "Remove the source path after successfully archiving the content."
+      }
+    ]
+  },
+  {
+    "name": "Open-ADTSession",
+    "synopsis": "Opens a new ADT session.",
+    "description": "This function initializes and opens a new ADT session with the specified parameters. It handles the setup of the session environment and processes any callbacks defined for the session. If the session fails to open, it handles the error and closes the session if necessary.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Open-ADTSession",
+    "parameters": [
+      {
+        "name": "SessionState",
+        "description": "Defaults to $PSCmdlet.SessionState to get the caller's SessionState, so only required if you need to override this."
+      },
+      {
+        "name": "DeploymentType",
+        "description": "Specifies the type of deployment: Install, Uninstall, or Repair."
+      },
+      {
+        "name": "DeployMode",
+        "description": "Specifies the deployment mode: Interactive, NonInteractive, or Silent."
+      },
+      {
+        "name": "SuppressRebootPassThru",
+        "description": "Suppresses reboot pass-through."
+      },
+      {
+        "name": "TerminalServerMode",
+        "description": "Enables Terminal Server mode."
+      },
+      {
+        "name": "DisableLogging",
+        "description": "Disables logging for the session."
+      },
+      {
+        "name": "AppVendor",
+        "description": "Specifies the application vendor."
+      },
+      {
+        "name": "AppName",
+        "description": "Specifies the application name."
+      },
+      {
+        "name": "AppVersion",
+        "description": "Specifies the application version."
+      },
+      {
+        "name": "AppArch",
+        "description": "Specifies the application architecture."
+      },
+      {
+        "name": "AppLang",
+        "description": "Specifies the application language."
+      },
+      {
+        "name": "AppRevision",
+        "description": "Specifies the application revision."
+      },
+      {
+        "name": "AppScriptVersion",
+        "description": "Specifies the application script version."
+      },
+      {
+        "name": "AppScriptDate",
+        "description": "Specifies the application script date."
+      },
+      {
+        "name": "AppScriptAuthor",
+        "description": "Specifies the application script author."
+      },
+      {
+        "name": "InstallName",
+        "description": "Specifies the install name."
+      },
+      {
+        "name": "InstallTitle",
+        "description": "Specifies the install title."
+      },
+      {
+        "name": "DeployAppScriptFriendlyName",
+        "description": "Specifies the friendly name of the deploy application script."
+      },
+      {
+        "name": "DeployAppScriptVersion",
+        "description": "Specifies the version of the deploy application script."
+      },
+      {
+        "name": "DeployAppScriptParameters",
+        "description": "Specifies the parameters for the deploy application script."
+      },
+      {
+        "name": "AppSuccessExitCodes",
+        "description": "Specifies the application exit codes."
+      },
+      {
+        "name": "AppRebootExitCodes",
+        "description": "Specifies the application reboot codes."
+      },
+      {
+        "name": "AppProcessesToClose",
+        "description": "Specifies one or more processes that require closing to ensure a successful deployment."
+      },
+      {
+        "name": "RequireAdmin",
+        "description": "Specifies that this deployment requires administrative permissions."
+      },
+      {
+        "name": "ScriptDirectory",
+        "description": "Specifies the base path for Files and SupportFiles."
+      },
+      {
+        "name": "DirFiles",
+        "description": "Specifies the override path to Files."
+      },
+      {
+        "name": "DirSupportFiles",
+        "description": "Specifies the override path to SupportFiles."
+      },
+      {
+        "name": "DefaultMsiFile",
+        "description": "Specifies the default MSI file."
+      },
+      {
+        "name": "DefaultMstFile",
+        "description": "Specifies the default MST file."
+      },
+      {
+        "name": "DefaultMspFiles",
+        "description": "Specifies the default MSP files."
+      },
+      {
+        "name": "DisableDefaultMsiProcessList",
+        "description": "Specifies that the zero-config MSI code should not gather process names from the MSI file."
+      },
+      {
+        "name": "ForceMsiDetection",
+        "description": "Specifies that MSI files should be detected and parsed during session initialization, irrespective of whether any App values are provided."
+      },
+      {
+        "name": "ForceWimDetection",
+        "description": "Specifies that WIM files should be detected and mounted during session initialization, irrespective of whether any App values are provided."
+      },
+      {
+        "name": "NoSessionDetection",
+        "description": "When DeployMode is not specified or is Auto, bypasses DeployMode adjustment when there's no logged on user session available."
+      },
+      {
+        "name": "NoOobeDetection",
+        "description": "When DeployMode is not specified or is Auto, bypasses DeployMode adjustment when the device hasn't completed the OOBE or a user ESP is active."
+      },
+      {
+        "name": "NoProcessDetection",
+        "description": "When DeployMode is not specified or is Auto, bypasses DeployMode adjustment when there's no processes to close in the specified AppProcessesToClose list."
+      },
+      {
+        "name": "PassThru",
+        "description": "Passes the session object through the pipeline."
+      },
+      {
+        "name": "LogName",
+        "description": "Specifies an override for the default-generated log file name."
+      },
+      {
+        "name": "SessionClass",
+        "description": "Specifies an override for PSADT.Module.DeploymentSession class. Use this if you're deriving a class inheriting off PSAppDeployToolkit's base."
+      },
+      {
+        "name": "UnboundArguments",
+        "description": "Captures any additional arguments passed to the function."
+      }
+    ]
+  },
+  {
+    "name": "Out-ADTPowerShellEncodedCommand",
+    "synopsis": "Encodes a PowerShell command into a Base64 string.",
+    "description": "This function takes a PowerShell command as input and encodes it into a Base64 string. This is useful for passing commands to PowerShell through mechanisms that require encoded input.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Out-ADTPowerShellEncodedCommand",
+    "parameters": [
+      {
+        "name": "Command",
+        "description": "The PowerShell command to be encoded."
+      }
+    ]
+  },
+  {
+    "name": "Register-ADTDll",
+    "synopsis": "Register a DLL file.",
+    "description": "This function registers a DLL file using regsvr32.exe. It ensures that the specified DLL file exists before attempting to register it. If the file does not exist, it throws an error.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Register-ADTDll",
+    "parameters": [
+      {
+        "name": "FilePath",
+        "description": "Path to the DLL file."
+      }
+    ]
+  },
+  {
+    "name": "Remove-ADTContentFromCache",
+    "synopsis": "Removes the toolkit content from the cache folder on the local machine and reverts the $adtSession.DirFiles and $adtSession.SupportFiles directory.",
+    "description": "This function removes the toolkit content from the cache folder on the local machine. It also reverts the $adtSession.DirFiles and $adtSession.SupportFiles directory to their original state. If the specified cache folder does not exist, it logs a message and exits.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Remove-ADTContentFromCache",
+    "parameters": [
+      {
+        "name": "LiteralPath",
+        "description": "The path to the software cache folder."
+      }
+    ]
+  },
+  {
+    "name": "Remove-ADTEdgeExtension",
+    "synopsis": "Removes an extension for Microsoft Edge using the ExtensionSettings policy.",
+    "description": "This function removes an extension for Microsoft Edge using the ExtensionSettings policy: https://learn.microsoft.com/en-us/deployedge/microsoft-edge-manage-extensions-ref-guide. This enables Edge Extensions to be installed and managed like applications, enabling extensions to be pushed to specific devices or users alongside existing GPO/Intune extension policies. This should not be used in conjunction with Edge Management Service which leverages the same registry key to configure Edge extensions.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Remove-ADTEdgeExtension",
+    "parameters": [
+      {
+        "name": "ExtensionID",
+        "description": "The ID of the extension to remove."
+      }
+    ]
+  },
+  {
+    "name": "Remove-ADTEnvironmentVariable",
+    "synopsis": "Removes the specified environment variable.",
+    "description": "This function removes the specified environment variable.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Remove-ADTEnvironmentVariable",
+    "parameters": [
+      {
+        "name": "Variable",
+        "description": "The variable to remove."
+      },
+      {
+        "name": "Target",
+        "description": "The target of the variable to remove. This can be the machine, user, or process."
+      }
+    ]
+  },
+  {
+    "name": "Remove-ADTFile",
+    "synopsis": "Removes one or more items from a given path on the filesystem.",
+    "description": "This function removes one or more items from a given path on the filesystem. It can handle both wildcard paths and literal paths. If the specified path does not exist, it logs a warning instead of throwing an error. The function can also delete items recursively if the Recurse parameter is specified.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Remove-ADTFile",
+    "parameters": [
+      {
+        "name": "Path",
+        "description": "Specifies the file on the filesystem to be removed. The value of Path will accept wildcards. Will accept an array of values."
+      },
+      {
+        "name": "LiteralPath",
+        "description": "Specifies the file on the filesystem to be removed. The value of LiteralPath is used exactly as it is typed; no characters are interpreted as wildcards. Will accept an array of values."
+      },
+      {
+        "name": "Recurse",
+        "description": "Deletes the files in the specified location(s) and in all child items of the location(s)."
+      }
+    ]
+  },
+  {
+    "name": "Remove-ADTFileFromUserProfiles",
+    "synopsis": "Removes one or more items from each user profile on the system.",
+    "description": "This function removes one or more items from each user profile on the system. It can handle both wildcard paths and literal paths. If the specified path does not exist, it logs a warning instead of throwing an error. The function can also delete items recursively if the Recurse parameter is specified. Additionally, it allows excluding specific NT accounts, system profiles, service profiles, and the default user profile.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Remove-ADTFileFromUserProfiles",
+    "parameters": [
+      {
+        "name": "Path",
+        "description": "Specifies the path to append to the root of the user profile to be resolved. The value of Path will accept wildcards. Will accept an array of values."
+      },
+      {
+        "name": "LiteralPath",
+        "description": "Specifies the path to append to the root of the user profile to be resolved. The value of LiteralPath is used exactly as it is typed; no characters are interpreted as wildcards. Will accept an array of values."
+      },
+      {
+        "name": "Recurse",
+        "description": "Deletes the files in the specified location(s) and in all child items of the location(s)."
+      },
+      {
+        "name": "ExcludeNTAccount",
+        "description": "Specify NT account names in Domain\\Username format to exclude from the list of user profiles."
+      },
+      {
+        "name": "ExcludeDefaultUser",
+        "description": "Exclude the Default User."
+      },
+      {
+        "name": "IncludeSystemProfiles",
+        "description": "Include system profiles: SYSTEM, LOCAL SERVICE, NETWORK SERVICE."
+      },
+      {
+        "name": "IncludeServiceProfiles",
+        "description": "Include service profiles where NTAccount begins with NT SERVICE."
+      }
+    ]
+  },
+  {
+    "name": "Remove-ADTFolder",
+    "synopsis": "Remove folder and files if they exist.",
+    "description": "This function removes a folder and all files within it, with or without recursion, in a given path. If the specified folder does not exist, it logs a warning instead of throwing an error. The function can also delete items recursively if the DisableRecursion parameter is not specified.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Remove-ADTFolder",
+    "parameters": [
+      {
+        "name": "Path",
+        "description": "A path to the folder to remove. Can contain wildcards."
+      },
+      {
+        "name": "LiteralPath",
+        "description": "A literal path to the folder to remove."
+      },
+      {
+        "name": "InputObject",
+        "description": "A DirectoryInfo object to remove. Available for pipelining."
+      },
+      {
+        "name": "DisableRecursion",
+        "description": "Disables recursion while deleting."
+      }
+    ]
+  },
+  {
+    "name": "Remove-ADTHashtableNullOrEmptyValues",
+    "synopsis": "Removes any key/value pairs from the supplied hashtable where the value is null.",
+    "description": "This function removes any key/value pairs from the supplied hashtable where the value is null.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Remove-ADTHashtableNullOrEmptyValues",
+    "parameters": [
+      {
+        "name": "Hashtable",
+        "description": "The hashtable to remove null values from."
+      }
+    ]
+  },
+  {
+    "name": "Remove-ADTIniSection",
+    "synopsis": "Opens an INI file and removes the specified section.",
+    "description": "Opens an INI file and removes the specified section.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Remove-ADTIniSection",
+    "parameters": [
+      {
+        "name": "FilePath",
+        "description": "Path to the INI file."
+      },
+      {
+        "name": "Section",
+        "description": "Section within the INI file."
+      }
+    ]
+  },
+  {
+    "name": "Remove-ADTIniValue",
+    "synopsis": "Opens an INI file and removes the specified key or section.",
+    "description": "Opens an INI file and removes the specified key or section.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Remove-ADTIniValue",
+    "parameters": [
+      {
+        "name": "FilePath",
+        "description": "Path to the INI file."
+      },
+      {
+        "name": "Section",
+        "description": "Section within the INI file."
+      },
+      {
+        "name": "Key",
+        "description": "Key within the section of the INI file."
+      }
+    ]
+  },
+  {
+    "name": "Remove-ADTInvalidFileNameChars",
+    "synopsis": "Remove invalid characters from the supplied string.",
+    "description": "This function removes invalid characters from the supplied string and returns a valid filename as a string. It ensures that the resulting string does not contain any characters that are not allowed in filenames. This function should not be used for entire paths as '\\' is not a valid filename character.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Remove-ADTInvalidFileNameChars",
+    "parameters": [
+      {
+        "name": "Name",
+        "description": "Text to remove invalid filename characters from."
+      }
+    ]
+  },
+  {
+    "name": "Remove-ADTModuleCallback",
+    "synopsis": "Removes a callback function from the nominated hooking point.",
+    "description": "This function removes a specified callback function from the nominated hooking point.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Remove-ADTModuleCallback",
+    "parameters": [
+      {
+        "name": "Hookpoint",
+        "description": "Where you wish for the callback to be removed from."
+      },
+      {
+        "name": "Callback",
+        "description": "The callback function to remove from the nominated hooking point."
+      }
+    ]
+  },
+  {
+    "name": "Remove-ADTRegistryKey",
+    "synopsis": "Deletes the specified registry key or value.",
+    "description": "This function deletes the specified registry key or value. It can handle both registry keys and values, and it supports recursive deletion of registry keys. If the SID parameter is specified, it converts HKEY_CURRENT_USER registry keys to the HKEY_USERS\\$SID format, allowing for the manipulation of HKCU registry settings for all users on the system.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Remove-ADTRegistryKey",
+    "parameters": [
+      {
+        "name": "Path",
+        "description": "Path of the registry key to delete, wildcards permitted."
+      },
+      {
+        "name": "LiteralPath",
+        "description": "Literal path of the registry key to delete."
+      },
+      {
+        "name": "Name",
+        "description": "Name of the registry value to delete."
+      },
+      {
+        "name": "Wow6432Node",
+        "description": "Specify this switch to read the 32-bit registry (Wow6432Node) on 64-bit systems."
+      },
+      {
+        "name": "Recurse",
+        "description": "Delete registry key recursively."
+      },
+      {
+        "name": "SID",
+        "description": "The security identifier (SID) for a user. Specifying this parameter will convert a HKEY_CURRENT_USER registry key to the HKEY_USERS\\$SID format. Specify this parameter from the Invoke-ADTAllUsersRegistryAction function to read/edit HKCU registry settings for all users on the system."
+      }
+    ]
+  },
+  {
+    "name": "Reset-ADTDeferHistory",
+    "synopsis": "Reset the history of deferrals in the registry for the current application.",
+    "description": "Reset the history of deferrals in the registry for the current application.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Reset-ADTDeferHistory",
+    "parameters": []
+  },
+  {
+    "name": "Resolve-ADTErrorRecord",
+    "synopsis": "Enumerates ErrorRecord details.",
+    "description": "Enumerates an ErrorRecord, or a collection of ErrorRecord properties. This function can filter and display specific properties of the ErrorRecord, and can exclude certain parts of the error details.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Resolve-ADTErrorRecord",
+    "parameters": [
+      {
+        "name": "ErrorRecord",
+        "description": "The ErrorRecord to resolve. For usage in a catch block, you'd use the automatic variable `$PSItem`. For usage out of a catch block, you can access the global $Error array's first error (on index 0)."
+      },
+      {
+        "name": "Property",
+        "description": "The list of properties to display from the ErrorRecord. Use \"*\" to display all properties."
+      },
+      {
+        "name": "ExcludeErrorRecord",
+        "description": "Exclude ErrorRecord details as represented by $ErrorRecord."
+      },
+      {
+        "name": "ExcludeErrorInvocation",
+        "description": "Exclude ErrorRecord invocation information as represented by $ErrorRecord.InvocationInfo."
+      },
+      {
+        "name": "ExcludeErrorException",
+        "description": "Exclude ErrorRecord exception details as represented by $ErrorRecord.Exception."
+      },
+      {
+        "name": "IncludeErrorInnerException",
+        "description": "Includes further ErrorRecord inner exception details as represented by $ErrorRecord.Exception.InnerException. Will retrieve all inner exceptions if there is more than one."
+      }
+    ]
+  },
+  {
+    "name": "Send-ADTKeys",
+    "synopsis": "Send a sequence of keys to one or more application windows.",
+    "description": "Send a sequence of keys to one or more application windows. If the window title searched for returns more than one window, then all of them will receive the sent keys. Function does not work in SYSTEM context unless launched with \"psexec.exe -s -i\" to run it as an interactive process under the SYSTEM account.",
+    "link": "http://msdn.microsoft.com/en-us/library/System.Windows.Forms.SendKeys(v=vs.100).aspx",
+    "parameters": [
+      {
+        "name": "WindowTitle",
+        "description": "The title of the application window to search for using regex matching."
+      },
+      {
+        "name": "GetAllWindowTitles",
+        "description": "Get titles for all open windows on the system."
+      },
+      {
+        "name": "WindowHandle",
+        "description": "Send keys to a specific window where the Window Handle is already known."
+      },
+      {
+        "name": "Keys",
+        "description": "The sequence of keys to send. Info on Key input at: http://msdn.microsoft.com/en-us/library/System.Windows.Forms.SendKeys(v=vs.100).aspx"
+      },
+      {
+        "name": "WaitSeconds",
+        "description": "This parameter is obsolete and will be removed in PSAppDeployToolkit 4.2.0. Please use `-WaitDuration` instead."
+      },
+      {
+        "name": "WaitDuration",
+        "description": "An optional amount of time to wait after the sending of the keys."
+      }
+    ]
+  },
+  {
+    "name": "Set-ADTActiveSetup",
+    "synopsis": "Creates an Active Setup entry in the registry to execute a file for each user upon login.",
+    "description": "Active Setup allows handling of per-user changes registry/file changes upon login. A registry key is created in the HKLM registry hive which gets replicated to the HKCU hive when a user logs in. If the \"Version\" value of the Active Setup entry in HKLM is higher than the version value in HKCU, the file referenced in \"StubPath\" is executed. This Function: - Creates the registry entries in \"HKLM:\\SOFTWARE\\Microsoft\\Active Setup\\Installed Components\\$($adtSession.InstallName)\". - Creates StubPath value depending on the file extension of the $StubExePath parameter. - Handles Version value with YYYYMMDDHHMMSS granularity to permit re-installs on the same day and still trigger Active Setup after Version increase. - Copies/overwrites the StubPath file to $StubExePath destination path if file exists in 'Files' subdirectory of script directory. - Executes the StubPath file for the current user based on $NoExecuteForCurrentUser (no need to logout/login to trigger Active Setup).",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Set-ADTActiveSetup",
+    "parameters": [
+      {
+        "name": "StubExePath",
+        "description": "Use this parameter to specify the destination path of the file that will be executed upon user login. Note: Place the file you want users to execute in the '\\Files' subdirectory of the script directory and the toolkit will install it to the path specificed in this parameter."
+      },
+      {
+        "name": "Arguments",
+        "description": "Arguments to pass to the file being executed."
+      },
+      {
+        "name": "Wow6432Node",
+        "description": "Specify this switch to use Active Setup entry under Wow6432Node on a 64-bit OS."
+      },
+      {
+        "name": "ExecutionPolicy",
+        "description": "Specifies the ExecutionPolicy to set when StubExePath is a PowerShell script."
+      },
+      {
+        "name": "Version",
+        "description": "Optional. Specify version for Active setup entry. Active Setup is not triggered if Version value has more than 8 consecutive digits. Use commas to get around this limitation. Note: - Do not use this parameter if it is not necessary. PSADT will handle this parameter automatically using the time of the installation as the version number. - In Windows 10, scripts and executables might be blocked by AppLocker. Ensure that the path given to -StubExePath will permit end users to run scripts and executables unelevated."
+      },
+      {
+        "name": "Locale",
+        "description": "Optional. Arbitrary string used to specify the installation language of the file being executed. Not replicated to HKCU."
+      },
+      {
+        "name": "PurgeActiveSetupKey",
+        "description": "Remove Active Setup entry from HKLM registry hive. Will also load each logon user's HKCU registry hive to remove Active Setup entry. Function returns after purging."
+      },
+      {
+        "name": "DisableActiveSetup",
+        "description": "Disables the Active Setup entry so that the StubPath file will not be executed. This also enables -NoExecuteForCurrentUser."
+      },
+      {
+        "name": "NoExecuteForCurrentUser",
+        "description": "Specifies whether the StubExePath should be executed for the current user. Since this user is already logged in, the user won't have the application started without logging out and logging back in."
+      },
+      {
+        "name": "PassThru",
+        "description": "Returns a ProcessResult from the execution of the ActiveSetup configuration for the current user if `-PassThru` is provided."
+      }
+    ]
+  },
+  {
+    "name": "Set-ADTActiveSetupRegistryEntry",
+    "synopsis": "",
+    "description": "",
+    "link": "",
+    "parameters": []
+  },
+  {
+    "name": "Set-ADTDeferHistory",
+    "synopsis": "Set the history of deferrals in the registry for the current application.",
+    "description": "Set the history of deferrals in the registry for the current application.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Set-ADTDeferHistory",
+    "parameters": [
+      {
+        "name": "DeferTimesRemaining",
+        "description": "Specify the number of deferrals remaining."
+      },
+      {
+        "name": "DeferDeadline",
+        "description": "Specify the deadline for the deferral."
+      },
+      {
+        "name": "DeferRunInterval",
+        "description": "Specifies the time span that must elapse before prompting the user again if a process listed in 'CloseProcesses' is still running after a deferral. This helps address the issue where Intune retries installations shortly after a user defers, preventing multiple immediate prompts and improving the user experience. This parameter is specifically utilized within the `Show-ADTInstallationWelcome` function, and if specified, the current date and time will be used for the DeferRunIntervalLastTime."
+      },
+      {
+        "name": "DeferRunIntervalLastTime",
+        "description": "Specifies the last time the DeferRunInterval value was tested. This is set from within `Show-ADTInstallationWelcome` as required."
+      }
+    ]
+  },
+  {
+    "name": "Set-ADTEnvironmentVariable",
+    "synopsis": "Sets the value for the specified environment variable.",
+    "description": "This function sets the value for the specified environment variable.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Set-ADTEnvironmentVariable",
+    "parameters": [
+      {
+        "name": "Variable",
+        "description": "The variable to set."
+      },
+      {
+        "name": "Value",
+        "description": "The value to set to variable to."
+      },
+      {
+        "name": "Target",
+        "description": "The target of the variable to set. This can be the machine, user, or process."
+      }
+    ]
+  },
+  {
+    "name": "Set-ADTIniSection",
+    "synopsis": "Opens an INI file and sets the values of the specified section.",
+    "description": "Opens an INI file and sets the values of the specified section.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Set-ADTIniSection",
+    "parameters": [
+      {
+        "name": "FilePath",
+        "description": "Path to the INI file."
+      },
+      {
+        "name": "Section",
+        "description": "Section within the INI file."
+      },
+      {
+        "name": "Content",
+        "description": "A hashtable or dictionary object containing the key-value pairs to set in the specified section. Supply an ordered hashtable to preserve the order of supplied entries. Values can be strings, numbers, booleans, enums, or null. Supply $null or an empty hashtable in combination with -Overwrite to empty an entire section."
+      },
+      {
+        "name": "Overwrite",
+        "description": "Specifies whether the provided INI content should overwrite all existing section content."
+      },
+      {
+        "name": "Force",
+        "description": "Specifies whether the INI file should be created if it does not already exist."
+      }
+    ]
+  },
+  {
+    "name": "Set-ADTIniValue",
+    "synopsis": "Opens an INI file and sets the value of the specified section and key.",
+    "description": "Opens an INI file and sets the value of the specified section and key.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Set-ADTIniValue",
+    "parameters": [
+      {
+        "name": "FilePath",
+        "description": "Path to the INI file."
+      },
+      {
+        "name": "Section",
+        "description": "Section within the INI file."
+      },
+      {
+        "name": "Key",
+        "description": "Key within the section of the INI file."
+      },
+      {
+        "name": "Value",
+        "description": "Value for the key within the section of the INI file."
+      },
+      {
+        "name": "Force",
+        "description": "Specifies whether the INI file should be created if it does not already exist."
+      }
+    ]
+  },
+  {
+    "name": "Set-ADTItemPermission",
+    "synopsis": "Allows you to easily change permissions on files or folders.",
+    "description": "Allows you to easily change permissions on files or folders for a given user or group. You can add, remove or replace permissions, set inheritance and propagation.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Set-ADTItemPermission",
+    "parameters": [
+      {
+        "name": "LiteralPath",
+        "description": "Path to the folder or file you want to modify (ex: C:\\Temp)"
+      },
+      {
+        "name": "AccessControlList",
+        "description": "The ACL object to apply to the given path."
+      },
+      {
+        "name": "User",
+        "description": "One or more user names (ex: BUILTIN\\Users, DOMAIN\\Admin) to give the permissions to. If you want to use SID, prefix it with an asterisk * (ex: *S-1-5-18)"
+      },
+      {
+        "name": "Permission",
+        "description": "Permission or list of permissions to be set/added/removed/replaced. Permission DeleteSubdirectoriesAndFiles does not apply to files."
+      },
+      {
+        "name": "PermissionType",
+        "description": "Sets Access Control Type of the permissions."
+      },
+      {
+        "name": "Inheritance",
+        "description": "Sets permission inheritance. Does not apply to files. Multiple options can be specified. * None - The permission entry is not inherited by child objects. * ObjectInherit - The permission entry is inherited by child leaf objects. * ContainerInherit - The permission entry is inherited by child container objects."
+      },
+      {
+        "name": "Propagation",
+        "description": "Sets how to propagate inheritance. Does not apply to files. * None - Specifies that no inheritance flags are set. * NoPropagateInherit - Specifies that the permission entry is not propagated to child objects. * InheritOnly - Specifies that the permission entry is propagated only to child objects. This includes both container and leaf child objects."
+      },
+      {
+        "name": "Method",
+        "description": "Specifies which method will be used to apply the permissions. * AddAccessRule - Adds permissions rules but it does not remove previous permissions. * SetAccessRule - Overwrites matching permission rules with new ones. * ResetAccessRule - Removes matching permissions rules and then adds permission rules. * RemoveAccessRule - Removes matching permission rules. * RemoveAccessRuleAll - Removes all permission rules for specified user/s. * RemoveAccessRuleSpecific - Removes specific permissions."
+      },
+      {
+        "name": "EnableInheritance",
+        "description": "Enables inheritance on the files/folders."
+      },
+      {
+        "name": "DisableInheritance",
+        "description": "Disables inheritance, preserving permissions before doing so."
+      },
+      {
+        "name": "RemoveExplicitRules",
+        "description": "Removes non-inherited permissions from the object when enabling inheritance."
+      }
+    ]
+  },
+  {
+    "name": "Set-ADTMsiProperty",
+    "synopsis": "Set a property in the MSI property table.",
+    "description": "Set a property in the MSI property table.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Set-ADTMsiProperty",
+    "parameters": [
+      {
+        "name": "Database",
+        "description": "Specify a ComObject representing an MSI database opened in view/modify/update mode."
+      },
+      {
+        "name": "PropertyName",
+        "description": "The name of the property to be set/modified."
+      },
+      {
+        "name": "PropertyValue",
+        "description": "The value of the property to be set/modified."
+      }
+    ]
+  },
+  {
+    "name": "Set-ADTPowerShellCulture",
+    "synopsis": "Changes the current thread's Culture and UICulture to the specified culture.",
+    "description": "This function changes the current thread's Culture and UICulture to the specified culture.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Set-ADTPowerShellCulture",
+    "parameters": [
+      {
+        "name": "CultureInfo",
+        "description": "The culture to set the current thread's Culture and UICulture to. Can be a CultureInfo object, or any valid IETF BCP 47 language tag."
+      }
+    ]
+  },
+  {
+    "name": "Set-ADTRegistryKey",
+    "synopsis": "Creates or sets a registry key name, value, and value data.",
+    "description": "Creates a registry key name, value, and value data; it sets the same if it already exists. This function can also handle registry keys for specific user SIDs and 32-bit registry on 64-bit systems.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Set-ADTRegistryKey",
+    "parameters": [
+      {
+        "name": "LiteralPath",
+        "description": "The registry key path."
+      },
+      {
+        "name": "Name",
+        "description": "The value name."
+      },
+      {
+        "name": "Value",
+        "description": "The value data."
+      },
+      {
+        "name": "Type",
+        "description": "The type of registry value to create or set. DWord should be specified as a decimal."
+      },
+      {
+        "name": "MultiStringValueMode",
+        "description": "The mode to operate when working with MultiString objects. The default is replace, but add and remove modes are supported also."
+      },
+      {
+        "name": "Wow6432Node",
+        "description": "Specify this switch to write to the 32-bit registry (Wow6432Node) on 64-bit systems."
+      },
+      {
+        "name": "RegistryOptions",
+        "description": "Extra options to use while creating the key. This is useful for creating volatile keys that do not survive a reboot."
+      },
+      {
+        "name": "SID",
+        "description": "The security identifier (SID) for a user. Specifying this parameter will convert a HKEY_CURRENT_USER registry key to the HKEY_USERS\\$SID format. Specify this parameter from the Invoke-ADTAllUsersRegistryAction function to read/edit HKCU registry settings for all users on the system."
+      }
+    ]
+  },
+  {
+    "name": "Set-ADTServiceStartMode",
+    "synopsis": "Set the service startup mode.",
+    "description": "Set the service startup mode. This function allows you to configure the startup mode of a specified service. The startup modes available are: Automatic, Automatic (Delayed Start), Manual, Disabled, Boot, and System.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Set-ADTServiceStartMode",
+    "parameters": [
+      {
+        "name": "Service",
+        "description": "Specify the name of the service."
+      },
+      {
+        "name": "StartMode",
+        "description": "Specify startup mode for the service. Options: Automatic, Automatic (Delayed Start), Manual, Disabled, Boot, System."
+      }
+    ]
+  },
+  {
+    "name": "Set-ADTShortcut",
+    "synopsis": "Modifies a .lnk or .url type shortcut.",
+    "description": "Modifies a shortcut - .lnk or .url file, with configurable options. Only specify the parameters that you want to change.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Set-ADTShortcut",
+    "parameters": [
+      {
+        "name": "LiteralPath",
+        "description": "Path to the shortcut to be changed."
+      },
+      {
+        "name": "TargetPath",
+        "description": "Sets target path or URL that the shortcut launches."
+      },
+      {
+        "name": "Arguments",
+        "description": "Sets the arguments used against the target path."
+      },
+      {
+        "name": "IconLocation",
+        "description": "Sets location of the icon used for the shortcut."
+      },
+      {
+        "name": "IconIndex",
+        "description": "Sets the index of the icon. Executables, DLLs, ICO files with multiple icons need the icon index to be specified. This parameter is an Integer. The first index is 0."
+      },
+      {
+        "name": "Description",
+        "description": "Sets the description of the shortcut as can be seen in the shortcut's properties."
+      },
+      {
+        "name": "WorkingDirectory",
+        "description": "Sets working directory to be used for the target path."
+      },
+      {
+        "name": "WindowStyle",
+        "description": "Sets the shortcut's window style to be minimised, maximised, etc."
+      },
+      {
+        "name": "RunAsAdmin",
+        "description": "Sets the shortcut to require elevated permissions to run."
+      },
+      {
+        "name": "HotKey",
+        "description": "Sets the hotkey to launch the shortcut, e.g. \"CTRL+SHIFT+F\"."
+      }
+    ]
+  },
+  {
+    "name": "Set-CallerVariable",
+    "synopsis": "",
+    "description": "",
+    "link": "",
+    "parameters": []
+  },
+  {
+    "name": "Show-ADTBalloonTip",
+    "synopsis": "Displays a balloon tip notification in the system tray.",
+    "description": "Displays a balloon tip notification in the system tray. This function can be used to show notifications to the user with customizable text, title, icon, and display duration. For Windows 10 and above, balloon tips automatically get translated by the system into toast notifications.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Show-ADTBalloonTip",
+    "parameters": [
+      {
+        "name": "BalloonTipText",
+        "description": "Text of the balloon tip."
+      },
+      {
+        "name": "BalloonTipIcon",
+        "description": "Icon to be used. Options: 'Error', 'Info', 'None', 'Warning'."
+      },
+      {
+        "name": "BalloonTipTime",
+        "description": "Time in milliseconds to display the balloon tip. Default: 10000."
+      },
+      {
+        "name": "NoWait",
+        "description": "Creates the balloon tip asynchronously."
+      },
+      {
+        "name": "Force",
+        "description": "Creates the balloon tip irrespective of whether running silently or not."
+      }
+    ]
+  },
+  {
+    "name": "Show-ADTDialogBox",
+    "synopsis": "Display a custom dialog box with optional title, buttons, icon, and timeout.",
+    "description": "Display a custom dialog box with optional title, buttons, icon, and timeout. The default button is \"OK\", the default Icon is \"None\", and the default Timeout is None. Show-ADTInstallationPrompt is recommended over this function as it provides more customization and uses consistent branding with the other UI components.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Show-ADTDialogBox",
+    "parameters": [
+      {
+        "name": "Text",
+        "description": "Text in the message dialog box."
+      },
+      {
+        "name": "Buttons",
+        "description": "The button(s) to display on the dialog box."
+      },
+      {
+        "name": "DefaultButton",
+        "description": "The Default button that is selected. Options: First, Second, Third."
+      },
+      {
+        "name": "Icon",
+        "description": "Icon to display on the dialog box. Options: None, Stop, Question, Exclamation, Information."
+      },
+      {
+        "name": "NoWait",
+        "description": "Presents the dialog in a separate, independent thread so that the main process isn't stalled waiting for a response."
+      },
+      {
+        "name": "ExitOnTimeout",
+        "description": "Specifies whether to not exit the script if the UI times out."
+      },
+      {
+        "name": "NotTopMost",
+        "description": "Specifies whether the message box shouldn't be a system modal message box that appears in a topmost window."
+      },
+      {
+        "name": "Force",
+        "description": "Specifies whether the message box should appear irrespective of an ongoing DeploymentSession's DeployMode."
+      }
+    ]
+  },
+  {
+    "name": "Show-ADTHelpConsole",
+    "synopsis": "Displays a help console for the ADT module.",
+    "description": "Displays a help console for the ADT module in a new PowerShell window. The console provides a graphical interface to browse and view detailed help information for all commands exported by the ADT module. The help console includes a list box to select commands and a text box to display the full help content for the selected command.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Show-ADTHelpConsole",
+    "parameters": []
+  },
+  {
+    "name": "Show-ADTInstallationProgress",
+    "synopsis": "Displays a progress dialog in a separate thread with an updateable custom message.",
+    "description": "Creates a WPF window in a separate thread to display a marquee style progress ellipse with a custom message that can be updated. The status message supports line breaks. The first time this function is called in a script, it will display a balloon tip notification to indicate that the installation has started (provided balloon tips are enabled in the config.psd1 file).",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Show-ADTInstallationProgress",
+    "parameters": [
+      {
+        "name": "StatusMessage",
+        "description": "The status message to be displayed. The default status message is taken from the imported strings.psd1 file."
+      },
+      {
+        "name": "StatusMessageDetail",
+        "description": "The status message detail to be displayed with a fluent progress window. The default status message is taken from the imported strings.psd1 file."
+      },
+      {
+        "name": "StatusBarPercentage",
+        "description": "The percentage to display on the status bar. If null or not supplied, the status bar will continuously scroll."
+      },
+      {
+        "name": "MessageAlignment",
+        "description": "The text alignment to use for the status message."
+      },
+      {
+        "name": "WindowLocation",
+        "description": "The location of the dialog on the screen."
+      },
+      {
+        "name": "NotTopMost",
+        "description": "Specifies whether the progress window shouldn't be topmost."
+      },
+      {
+        "name": "AllowMove",
+        "description": "Specifies that the user can move the dialog on the screen."
+      }
+    ]
+  },
+  {
+    "name": "Show-ADTInstallationPrompt",
+    "synopsis": "Displays a custom installation prompt with the toolkit branding and optional buttons.",
+    "description": "Displays a custom installation prompt with the toolkit branding and optional buttons. Any combination of Left, Middle, or Right buttons can be displayed. The return value of the button clicked by the user is the button text specified. The prompt can also display a system icon and be configured to persist, minimize other windows, or timeout after a specified period.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Show-ADTInstallationPrompt",
+    "parameters": [
+      {
+        "name": "RequestInput",
+        "description": "Show a text box for the user to provide an answer."
+      },
+      {
+        "name": "DefaultValue",
+        "description": "The default value to show in the text box."
+      },
+      {
+        "name": "Message",
+        "description": "The message text to be displayed on the prompt."
+      },
+      {
+        "name": "MessageAlignment",
+        "description": "Alignment of the message text."
+      },
+      {
+        "name": "ButtonLeftText",
+        "description": "Show a button on the left of the prompt with the specified text."
+      },
+      {
+        "name": "ButtonRightText",
+        "description": "Show a button on the right of the prompt with the specified text."
+      },
+      {
+        "name": "ButtonMiddleText",
+        "description": "Show a button in the middle of the prompt with the specified text."
+      },
+      {
+        "name": "Icon",
+        "description": "Show a system icon in the prompt."
+      },
+      {
+        "name": "WindowLocation",
+        "description": "The location of the dialog on the screen."
+      },
+      {
+        "name": "NoWait",
+        "description": "Presents the dialog in a separate, independent thread so that the main process isn't stalled waiting for a response."
+      },
+      {
+        "name": "PersistPrompt",
+        "description": "Specify whether to make the prompt persist in the center of the screen every couple of seconds, specified in the config.psd1 file. The user will have no option but to respond to the prompt."
+      },
+      {
+        "name": "MinimizeWindows",
+        "description": "Specifies whether to minimize other windows when displaying prompt."
+      },
+      {
+        "name": "NoExitOnTimeout",
+        "description": "Specifies whether to not exit the script if the UI times out."
+      },
+      {
+        "name": "NotTopMost",
+        "description": "Specifies whether the prompt shouldn't be topmost, above all other windows."
+      },
+      {
+        "name": "AllowMove",
+        "description": "Specifies that the user can move the dialog on the screen."
+      }
+    ]
+  },
+  {
+    "name": "Show-ADTInstallationRestartPrompt",
+    "synopsis": "Displays a restart prompt with a countdown to a forced restart.",
+    "description": "Displays a restart prompt with a countdown to a forced restart. The prompt can be customized with a title, countdown duration, and whether it should be topmost. It also supports silent mode where the restart can be triggered without user interaction.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Show-ADTInstallationRestartPrompt",
+    "parameters": [
+      {
+        "name": "CountdownSeconds",
+        "description": "Specifies the number of seconds to display the restart prompt."
+      },
+      {
+        "name": "CountdownNoHideSeconds",
+        "description": "Specifies the number of seconds to display the restart prompt without allowing the window to be hidden."
+      },
+      {
+        "name": "SilentCountdownSeconds",
+        "description": "Specifies number of seconds to countdown for the restart when the toolkit is running in silent mode and `-SilentRestart` isn't specified."
+      },
+      {
+        "name": "SilentRestart",
+        "description": "Specifies whether the restart should be triggered when DeployMode is silent or very silent."
+      },
+      {
+        "name": "NoCountdown",
+        "description": "Specifies whether the user should receive a prompt to immediately restart their workstation."
+      },
+      {
+        "name": "WindowLocation",
+        "description": "The location of the dialog on the screen."
+      },
+      {
+        "name": "CustomText",
+        "description": "Specify whether to display a custom message specified in the `strings.psd1` file. Custom message must be populated for each language section in the `strings.psd1` file."
+      },
+      {
+        "name": "NotTopMost",
+        "description": "Specifies whether the prompt shouldn't be topmost, above all other windows."
+      },
+      {
+        "name": "AllowMove",
+        "description": "Specifies that the user can move the dialog on the screen."
+      }
+    ]
+  },
+  {
+    "name": "Show-ADTInstallationWelcome",
+    "synopsis": "Show a welcome dialog prompting the user with information about the deployment and actions to be performed before the deployment can begin.",
+    "description": "The following prompts can be included in the welcome dialog: * Close the specified running applications, or optionally close the applications without showing a prompt (using the `-Silent` switch). * Defer the deployment a certain number of times, for a certain number of days or until a deadline is reached. * Countdown until applications are automatically closed. * Prevent users from launching the specified applications while the deployment is in progress.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Show-ADTInstallationWelcome",
+    "parameters": [
+      {
+        "name": "CloseProcesses",
+        "description": "Name of the process to stop (do not include the .exe). Specify multiple processes separated by a comma. Specify custom descriptions like this: `@{ Name = 'winword'; Description = 'Microsoft Office Word' }, @{ Name = 'excel'; Description = 'Microsoft Office Excel' }`"
+      },
+      {
+        "name": "HideCloseButton",
+        "description": "Specifies that the 'Close Processes' button be hidden/disabled to force users to manually close down their running processes."
+      },
+      {
+        "name": "AllowDefer",
+        "description": "Enables an optional defer button to allow the user to defer the deployment."
+      },
+      {
+        "name": "AllowDeferCloseProcesses",
+        "description": "Enables an optional defer button to allow the user to defer the deployment only if there are running applications that need to be closed. This parameter automatically enables `-AllowDefer`."
+      },
+      {
+        "name": "Silent",
+        "description": "Stop processes without prompting the user."
+      },
+      {
+        "name": "CloseProcessesCountdown",
+        "description": "Option to provide a countdown in seconds until the specified applications are automatically closed. This only takes effect if deferral is not allowed or has expired."
+      },
+      {
+        "name": "ForceCloseProcessesCountdown",
+        "description": "Option to provide a countdown in seconds until the specified applications are automatically closed regardless of whether deferral is allowed."
+      },
+      {
+        "name": "ForceCountdown",
+        "description": "Specify a countdown to display before automatically proceeding with the deployment when a deferral is enabled."
+      },
+      {
+        "name": "DeferTimes",
+        "description": "Specify the number of times the deployment can be deferred."
+      },
+      {
+        "name": "DeferDays",
+        "description": "Specify the number of days since first run that the deployment can be deferred. This is converted to a deadline."
+      },
+      {
+        "name": "DeferDeadline",
+        "description": "Specify the deadline date until which the deployment can be deferred. Specify the date in the local culture if the script is intended for that same culture. If the script is intended to run on en-US machines, specify the date in the format: `08/25/2013`, or `08-25-2013`, or `08-25-2013 18:00:00`. If the script is intended for multiple cultures, specify the date in the universal sortable date/time format: `2013-08-22 11:51:52Z`. The deadline date will be displayed to the user in the format of their culture."
+      },
+      {
+        "name": "DeferRunInterval",
+        "description": "Specifies the time span that must elapse before prompting the user again if a process listed in 'CloseProcesses' is still running after a deferral. This addresses the issue where Intune retries deployments shortly after a user defers, preventing multiple immediate prompts and improving the user experience. Example: - To specify 30 minutes, use: `([System.TimeSpan]::FromMinutes(30))`. - To specify 24 hours, use: `([System.TimeSpan]::FromHours(24))`."
+      },
+      {
+        "name": "WindowLocation",
+        "description": "The location of the dialog on the screen."
+      },
+      {
+        "name": "BlockExecution",
+        "description": "Option to prevent the user from launching processes/applications, specified in -CloseProcesses, during the deployment."
+      },
+      {
+        "name": "PromptToSave",
+        "description": "Specify whether to prompt to save working documents when the user chooses to close applications by selecting the \"Close Programs\" button. Option does not work in SYSTEM context unless toolkit launched with \"psexec.exe -s -i\" to run it as an interactive process under the SYSTEM account."
+      },
+      {
+        "name": "PersistPrompt",
+        "description": "Specify whether to make the Show-ADTInstallationWelcome prompt persist in the center of the screen every couple of seconds, specified in the config.psd1. The user will have no option but to respond to the prompt. This only takes effect if deferral is not allowed or has expired."
+      },
+      {
+        "name": "MinimizeWindows",
+        "description": "Specifies whether to minimize other windows when displaying prompt."
+      },
+      {
+        "name": "NoMinimizeWindows",
+        "description": "This parameter will be removed in PSAppDeployToolkit 4.2.0."
+      },
+      {
+        "name": "NotTopMost",
+        "description": "Specifies whether the windows is the topmost window."
+      },
+      {
+        "name": "AllowMove",
+        "description": "Specifies that the user can move the dialog on the screen."
+      },
+      {
+        "name": "CustomText",
+        "description": "Specify whether to display a custom message as specified in the `strings.psd1` file below the main preamble. Custom message must be populated for each language section in the `strings.psd1` file."
+      },
+      {
+        "name": "CheckDiskSpace",
+        "description": "Specify whether to check if there is enough disk space for the deployment to proceed. If this parameter is specified without the RequiredDiskSpace parameter, the required disk space is calculated automatically based on the size of the script source and associated files."
+      },
+      {
+        "name": "RequiredDiskSpace",
+        "description": "Specify required disk space in MB, used in combination with CheckDiskSpace."
+      }
+    ]
+  },
+  {
+    "name": "Show-ADTWelcomePrompt",
+    "synopsis": "",
+    "description": "",
+    "link": "",
+    "parameters": []
+  },
+  {
+    "name": "Start-ADTMsiProcess",
+    "synopsis": "Executes msiexec.exe to perform actions such as install, uninstall, patch, repair, or active setup for MSI and MSP files or MSI product codes.",
+    "description": "This function utilizes msiexec.exe to handle various operations on MSI and MSP files, as well as MSI product codes. The operations include installation, uninstallation, patching, repair, and setting up active configurations. If the -Action parameter is set to \"Install\" and the MSI is already installed, the function will terminate without performing any actions. The function automatically sets default switches for msiexec based on preferences defined in the config.psd1 file. Additionally, it generates a log file name and creates a verbose log for all msiexec operations, ensuring detailed tracking. The MSI or MSP file is expected to reside in the \"Files\" subdirectory of the App Deploy Toolkit, with transform files expected to be in the same directory as the MSI file.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Start-ADTMsiProcess",
+    "parameters": [
+      {
+        "name": "Action",
+        "description": "Specifies the action to be performed. Available options: Install, Uninstall, Patch, Repair, ActiveSetup."
+      },
+      {
+        "name": "FilePath",
+        "description": "The file path to the MSI/MSP file."
+      },
+      {
+        "name": "ProductCode",
+        "description": "The product code of the installed MSI."
+      },
+      {
+        "name": "InstalledApplication",
+        "description": "The InstalledApplication object of the installed MSI."
+      },
+      {
+        "name": "ArgumentList",
+        "description": "Overrides the default parameters specified in the config.psd1 file."
+      },
+      {
+        "name": "AdditionalArgumentList",
+        "description": "Adds additional parameters to the default set specified in the config.psd1 file."
+      },
+      {
+        "name": "SecureArgumentList",
+        "description": "Hides all parameters passed to the MSI or MSP file from the toolkit log file."
+      },
+      {
+        "name": "WorkingDirectory",
+        "description": "Overrides the working directory. The working directory is set to the location of the MSI file."
+      },
+      {
+        "name": "Transforms",
+        "description": "The name(s) of the transform file(s) to be applied to the MSI. The transform files should be in the same directory as the MSI file."
+      },
+      {
+        "name": "Patches",
+        "description": "The name(s) of the patch (MSP) file(s) to be applied to the MSI for the \"Install\" action. The patch files should be in the same directory as the MSI file."
+      },
+      {
+        "name": "RunAsActiveUser",
+        "description": "A RunAsActiveUser object to invoke the process as."
+      },
+      {
+        "name": "UseLinkedAdminToken",
+        "description": "Use a user's linked administrative token while running the process under their context."
+      },
+      {
+        "name": "UseHighestAvailableToken",
+        "description": "Use a user's linked administrative token if it's available while running the process under their context."
+      },
+      {
+        "name": "InheritEnvironmentVariables",
+        "description": "Specifies whether the process running as a user should inherit the SYSTEM account's environment variables."
+      },
+      {
+        "name": "UseUnelevatedToken",
+        "description": "If the current process is elevated, starts the new process unelevated using the user's unelevated linked token."
+      },
+      {
+        "name": "ExpandEnvironmentVariables",
+        "description": "Specifies whether to expand any Windows/DOS-style environment variables in the specified FilePath/ArgumentList."
+      },
+      {
+        "name": "LoggingOptions",
+        "description": "Overrides the default logging options specified in the config.psd1 file."
+      },
+      {
+        "name": "LogFileName",
+        "description": "Overrides the default log file name. The default log file name is generated from the MSI file name. If LogFileName does not end in .log, it will be automatically appended. For uninstallations, by default the product code is resolved to the DisplayName and version of the application."
+      },
+      {
+        "name": "RepairMode",
+        "description": "Specifies the mode of repair. Choosing `Repair` will repair via `msiexec.exe /p` (which can trigger unsupressable reboots). Choosing `Reinstall` will reinstall by adding `REINSTALL=ALL REINSTALLMODE=omus` to the standard InstallParams."
+      },
+      {
+        "name": "RepairFromSource",
+        "description": "Specifies whether we should repair from source. Also rewrites local cache."
+      },
+      {
+        "name": "SkipMSIAlreadyInstalledCheck",
+        "description": "Skips the check to determine if the MSI is already installed on the system."
+      },
+      {
+        "name": "IncludeUpdatesAndHotfixes",
+        "description": "Include matches against updates and hotfixes in results."
+      },
+      {
+        "name": "SuccessExitCodes",
+        "description": "List of exit codes to be considered successful. Defaults to values set during ADTSession initialization, otherwise: 0"
+      },
+      {
+        "name": "RebootExitCodes",
+        "description": "List of exit codes to indicate a reboot is required. Defaults to values set during ADTSession initialization, otherwise: 1641, 3010"
+      },
+      {
+        "name": "IgnoreExitCodes",
+        "description": "List the exit codes to ignore or * to ignore all exit codes."
+      },
+      {
+        "name": "PriorityClass",
+        "description": "Specifies priority class for the process. Options: Idle, Normal, High, AboveNormal, BelowNormal, RealTime."
+      },
+      {
+        "name": "ExitOnProcessFailure",
+        "description": "Automatically closes the active deployment session via Close-ADTSession in the event the process exits with a non-success or non-ignored exit code."
+      },
+      {
+        "name": "NoDesktopRefresh",
+        "description": "If specifies, doesn't refresh the desktop and environment after successful MSI installation."
+      },
+      {
+        "name": "NoWait",
+        "description": "Immediately continue after executing the process."
+      },
+      {
+        "name": "PassThru",
+        "description": "Returns ExitCode, StdOut, and StdErr output from the process. Note that a failed execution will only return an object if either `-ErrorAction` is set to `SilentlyContinue`/`Ignore`, or if `-IgnoreExitCodes`/`-SuccessExitCodes` are used."
+      }
+    ]
+  },
+  {
+    "name": "Start-ADTMsiProcessAsUser",
+    "synopsis": "Executes msiexec.exe to perform actions such as install, uninstall, patch, repair, or active setup for MSI and MSP files or MSI product codes.",
+    "description": "This function utilizes msiexec.exe to handle various operations on MSI and MSP files, as well as MSI product codes. The operations include installation, uninstallation, patching, repair, and setting up active configurations. If the -Action parameter is set to \"Install\" and the MSI is already installed, the function will terminate without performing any actions. The function automatically sets default switches for msiexec based on preferences defined in the config.psd1 file. Additionally, it generates a log file name and creates a verbose log for all msiexec operations, ensuring detailed tracking. The MSI or MSP file is expected to reside in the \"Files\" subdirectory of the App Deploy Toolkit, with transform files expected to be in the same directory as the MSI file.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Start-ADTMsiProcessAsUser",
+    "parameters": [
+      {
+        "name": "Action",
+        "description": "Specifies the action to be performed. Available options: Install, Uninstall, Patch, Repair, ActiveSetup."
+      },
+      {
+        "name": "FilePath",
+        "description": "The file path to the MSI/MSP file."
+      },
+      {
+        "name": "ProductCode",
+        "description": "The product code of the installed MSI."
+      },
+      {
+        "name": "InstalledApplication",
+        "description": "The InstalledApplication object of the installed MSI."
+      },
+      {
+        "name": "ArgumentList",
+        "description": "Overrides the default parameters specified in the config.psd1 file."
+      },
+      {
+        "name": "AdditionalArgumentList",
+        "description": "Adds additional parameters to the default set specified in the config.psd1 file."
+      },
+      {
+        "name": "SecureArgumentList",
+        "description": "Hides all parameters passed to the MSI or MSP file from the toolkit log file."
+      },
+      {
+        "name": "WorkingDirectory",
+        "description": "Overrides the working directory. The working directory is set to the location of the MSI file."
+      },
+      {
+        "name": "Transforms",
+        "description": "The name(s) of the transform file(s) to be applied to the MSI. The transform files should be in the same directory as the MSI file."
+      },
+      {
+        "name": "Patches",
+        "description": "The name(s) of the patch (MSP) file(s) to be applied to the MSI for the \"Install\" action. The patch files should be in the same directory as the MSI file."
+      },
+      {
+        "name": "Username",
+        "description": "A username to invoke the process as. Only supported while running as the SYSTEM account."
+      },
+      {
+        "name": "UseLinkedAdminToken",
+        "description": "Use a user's linked administrative token while running the process under their context."
+      },
+      {
+        "name": "UseHighestAvailableToken",
+        "description": "Use a user's linked administrative token if it's available while running the process under their context."
+      },
+      {
+        "name": "InheritEnvironmentVariables",
+        "description": "Specifies whether the process running as a user should inherit the SYSTEM account's environment variables."
+      },
+      {
+        "name": "ExpandEnvironmentVariables",
+        "description": "Specifies whether to expand any Windows/DOS-style environment variables in the specified FilePath/ArgumentList."
+      },
+      {
+        "name": "LoggingOptions",
+        "description": "Overrides the default logging options specified in the config.psd1 file."
+      },
+      {
+        "name": "LogFileName",
+        "description": "Overrides the default log file name. The default log file name is generated from the MSI file name. If LogFileName does not end in .log, it will be automatically appended. For uninstallations, by default the product code is resolved to the DisplayName and version of the application."
+      },
+      {
+        "name": "RepairMode",
+        "description": "Specifies the mode of repair. Choosing `Repair` will repair via `msiexec.exe /p` (which can trigger unsupressable reboots). Choosing `Reinstall` will reinstall by adding `REINSTALL=ALL REINSTALLMODE=omus` to the standard InstallParams."
+      },
+      {
+        "name": "RepairFromSource",
+        "description": "Specifies whether we should repair from source. Also rewrites local cache."
+      },
+      {
+        "name": "SkipMSIAlreadyInstalledCheck",
+        "description": "Skips the check to determine if the MSI is already installed on the system."
+      },
+      {
+        "name": "IncludeUpdatesAndHotfixes",
+        "description": "Include matches against updates and hotfixes in results."
+      },
+      {
+        "name": "SuccessExitCodes",
+        "description": "List of exit codes to be considered successful. Defaults to values set during ADTSession initialization, otherwise: 0"
+      },
+      {
+        "name": "RebootExitCodes",
+        "description": "List of exit codes to indicate a reboot is required. Defaults to values set during ADTSession initialization, otherwise: 1641, 3010"
+      },
+      {
+        "name": "IgnoreExitCodes",
+        "description": "List the exit codes to ignore or * to ignore all exit codes."
+      },
+      {
+        "name": "PriorityClass",
+        "description": "Specifies priority class for the process. Options: Idle, Normal, High, AboveNormal, BelowNormal, RealTime."
+      },
+      {
+        "name": "ExitOnProcessFailure",
+        "description": "Automatically closes the active deployment session via Close-ADTSession in the event the process exits with a non-success or non-ignored exit code."
+      },
+      {
+        "name": "NoDesktopRefresh",
+        "description": "If specifies, doesn't refresh the desktop and environment after successful MSI installation."
+      },
+      {
+        "name": "NoWait",
+        "description": "Immediately continue after executing the process."
+      },
+      {
+        "name": "PassThru",
+        "description": "Returns ExitCode, StdOut, and StdErr output from the process. Note that a failed execution will only return an object if either `-ErrorAction` is set to `SilentlyContinue`/`Ignore`, or if `-IgnoreExitCodes`/`-SuccessExitCodes` are used."
+      }
+    ]
+  },
+  {
+    "name": "Start-ADTMspProcess",
+    "synopsis": "Executes an MSP file using the same logic as Start-ADTMsiProcess.",
+    "description": "Reads SummaryInfo targeted product codes in MSP file and determines if the MSP file applies to any installed products. If a valid installed product is found, triggers the Start-ADTMsiProcess function to patch the installation. Uses default config MSI parameters. You can use -AdditionalArgumentList to add additional parameters.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Start-ADTMspProcess",
+    "parameters": [
+      {
+        "name": "FilePath",
+        "description": "Path to the MSP file."
+      },
+      {
+        "name": "AdditionalArgumentList",
+        "description": "Additional parameters."
+      },
+      {
+        "name": "RunAsActiveUser",
+        "description": "A RunAsActiveUser object to invoke the process as."
+      },
+      {
+        "name": "UseLinkedAdminToken",
+        "description": "Use a user's linked administrative token while running the process under their context."
+      },
+      {
+        "name": "UseHighestAvailableToken",
+        "description": "Use a user's linked administrative token if it's available while running the process under their context."
+      },
+      {
+        "name": "InheritEnvironmentVariables",
+        "description": "Specifies whether the process running as a user should inherit the SYSTEM account's environment variables."
+      },
+      {
+        "name": "UseUnelevatedToken",
+        "description": "If the current process is elevated, starts the new process unelevated using the user's unelevated linked token."
+      },
+      {
+        "name": "ExpandEnvironmentVariables",
+        "description": "Specifies whether to expand any Windows/DOS-style environment variables in the specified FilePath/ArgumentList."
+      }
+    ]
+  },
+  {
+    "name": "Start-ADTMspProcessAsUser",
+    "synopsis": "Executes an MSP file using the same logic as Start-ADTMsiProcess.",
+    "description": "Reads SummaryInfo targeted product codes in MSP file and determines if the MSP file applies to any installed products. If a valid installed product is found, triggers the Start-ADTMsiProcess function to patch the installation. Uses default config MSI parameters. You can use -AdditionalArgumentList to add additional parameters.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Start-ADTMspProcessAsUser",
+    "parameters": [
+      {
+        "name": "FilePath",
+        "description": "Path to the MSP file."
+      },
+      {
+        "name": "AdditionalArgumentList",
+        "description": "Additional parameters."
+      },
+      {
+        "name": "Username",
+        "description": "A username to invoke the process as. Only supported while running as the SYSTEM account."
+      },
+      {
+        "name": "UseLinkedAdminToken",
+        "description": "Use a user's linked administrative token while running the process under their context."
+      },
+      {
+        "name": "UseHighestAvailableToken",
+        "description": "Use a user's linked administrative token if it's available while running the process under their context."
+      },
+      {
+        "name": "InheritEnvironmentVariables",
+        "description": "Specifies whether the process running as a user should inherit the SYSTEM account's environment variables."
+      },
+      {
+        "name": "ExpandEnvironmentVariables",
+        "description": "Specifies whether to expand any Windows/DOS-style environment variables in the specified FilePath/ArgumentList."
+      }
+    ]
+  },
+  {
+    "name": "Start-ADTProcess",
+    "synopsis": "Execute a process with optional arguments, working directory, window style.",
+    "description": "Executes a process, e.g. a file included in the Files directory of the App Deploy Toolkit, or a file on the local machine. Provides various options for handling the return codes (see Parameters).",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Start-ADTProcess",
+    "parameters": [
+      {
+        "name": "FilePath",
+        "description": "Path to the file to be executed. If the file is located directly in the \"Files\" directory of the App Deploy Toolkit, only the file name needs to be specified. Otherwise, the full path of the file must be specified. If the files is in a subdirectory of \"Files\", use the \"$($adtSession.DirFiles)\" variable as shown in the example."
+      },
+      {
+        "name": "ArgumentList",
+        "description": "Arguments to be passed to the executable."
+      },
+      {
+        "name": "SecureArgumentList",
+        "description": "Hides all parameters passed to the executable from the Toolkit log file."
+      },
+      {
+        "name": "WorkingDirectory",
+        "description": "The working directory used for executing the process. Defaults to DirFiles if there is an active DeploymentSession. The use of UseShellExecute affects this parameter."
+      },
+      {
+        "name": "RunAsActiveUser",
+        "description": "A RunAsActiveUser object to invoke the process as."
+      },
+      {
+        "name": "UseLinkedAdminToken",
+        "description": "Use a user's linked administrative token while running the process under their context."
+      },
+      {
+        "name": "UseHighestAvailableToken",
+        "description": "Use a user's linked administrative token if it's available while running the process under their context."
+      },
+      {
+        "name": "InheritEnvironmentVariables",
+        "description": "Specifies whether the process running as a user should inherit the SYSTEM account's environment variables."
+      },
+      {
+        "name": "UseUnelevatedToken",
+        "description": "If the current process is elevated, starts the new process unelevated using the user's unelevated linked token."
+      },
+      {
+        "name": "UseShellExecute",
+        "description": "Specifies whether to use the operating system shell to start the process. $true if the shell should be used when starting the process; $false if the process should be created directly from the executable file. The word \"Shell\" in this context refers to a graphical shell (similar to the Windows shell) rather than command shells (for example, bash or sh) and lets users launch graphical applications or open documents. It lets you open a file or a url and the Shell will figure out the program to open it with. The WorkingDirectory property behaves differently depending on the value of the UseShellExecute property. When UseShellExecute is true, the WorkingDirectory property specifies the location of the executable. When UseShellExecute is false, the WorkingDirectory property is not used to find the executable. Instead, it is used only by the process that is started and has meaning only within the context of the new process. If you set UseShellExecute to $true, there will be no available output from the process."
+      },
+      {
+        "name": "Verb",
+        "description": "The verb to use when doing a ShellExecute invocation. Common usages are \"runas\" to trigger a UAC elevation of the process."
+      },
+      {
+        "name": "ExpandEnvironmentVariables",
+        "description": "Specifies whether to expand any Windows/DOS-style environment variables in the specified FilePath/ArgumentList."
+      },
+      {
+        "name": "WindowStyle",
+        "description": "Style of the window of the process executed. Options: Normal, Hidden, Maximized, Minimized. Only works for native Windows GUI applications. If the WindowStyle is set to Hidden, UseShellExecute should be set to $true. Note: Not all processes honor WindowStyle. WindowStyle is a recommendation passed to the process. They can choose to ignore it."
+      },
+      {
+        "name": "CreateNoWindow",
+        "description": "Specifies whether the process should be started with a new window to contain it."
+      },
+      {
+        "name": "StreamEncoding",
+        "description": "Specifies the encoding type to use when reading stdout/stderr. Some apps like WinGet encode using UTF8, which will corrupt if incorrectly set."
+      },
+      {
+        "name": "NoStreamLogging",
+        "description": "Don't log any available stdout/stderr data to the log file."
+      },
+      {
+        "name": "WaitForMsiExec",
+        "description": "Sometimes an EXE bootstrapper will launch an MSI install. In such cases, this variable will ensure that this function waits for the msiexec engine to become available before starting the install."
+      },
+      {
+        "name": "MsiExecWaitTime",
+        "description": "Specify the length of time in seconds to wait for the msiexec engine to become available."
+      },
+      {
+        "name": "WaitForChildProcesses",
+        "description": "Specifies whether the started process should be considered finished only when any child processes it spawns have finished also."
+      },
+      {
+        "name": "KillChildProcessesWithParent",
+        "description": "Specifies whether any child processes started by the provided executable should be closed when the provided executable closes. This is handy for application installs that open web browsers and other programs that cannot be suppressed."
+      },
+      {
+        "name": "Timeout",
+        "description": "How long to wait for the process before timing out."
+      },
+      {
+        "name": "TimeoutAction",
+        "description": "What action to take on timeout. Follows ErrorAction if not specified."
+      },
+      {
+        "name": "NoTerminateOnTimeout",
+        "description": "Indicates that the process should not be terminated on timeout. Only supported for GUI-based applications."
+      },
+      {
+        "name": "SuccessExitCodes",
+        "description": "List of exit codes to be considered successful. Defaults to values set during ADTSession initialization, otherwise: 0"
+      },
+      {
+        "name": "RebootExitCodes",
+        "description": "List of exit codes to indicate a reboot is required. Defaults to values set during ADTSession initialization, otherwise: 1641, 3010"
+      },
+      {
+        "name": "IgnoreExitCodes",
+        "description": "List the exit codes to ignore or * to ignore all exit codes. Where possible, please use `-SuccessExitCodes` and/or `-RebootExitCodes` instead."
+      },
+      {
+        "name": "PriorityClass",
+        "description": "Specifies priority class for the process. Options: Idle, Normal, High, AboveNormal, BelowNormal, RealTime."
+      },
+      {
+        "name": "ExitOnProcessFailure",
+        "description": "Automatically closes the active deployment session via Close-ADTSession in the event the process exits with a non-success or non-ignored exit code."
+      },
+      {
+        "name": "NoWait",
+        "description": "Immediately continue after executing the process."
+      },
+      {
+        "name": "PassThru",
+        "description": "If `-NoWait` is not specified, returns an object with ExitCode, StdOut, and StdErr output from the process. If `-NoWait` is specified, returns a task that can be awaited. Note that a failed execution will only return an object if either `-ErrorAction` is set to `SilentlyContinue`/`Ignore`, or if `-IgnoreExitCodes`/`-SuccessExitCodes` are used."
+      }
+    ]
+  },
+  {
+    "name": "Start-ADTProcessAsUser",
+    "synopsis": "Invokes a process in another user's session.",
+    "description": "Invokes a process from SYSTEM in another user's session.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Start-ADTProcess",
+    "parameters": [
+      {
+        "name": "FilePath",
+        "description": "Path to the file to be executed. If the file is located directly in the \"Files\" directory of the App Deploy Toolkit, only the file name needs to be specified. Otherwise, the full path of the file must be specified. If the files is in a subdirectory of \"Files\", use the \"$($adtSession.DirFiles)\" variable as shown in the example."
+      },
+      {
+        "name": "ArgumentList",
+        "description": "Arguments to be passed to the executable."
+      },
+      {
+        "name": "SecureArgumentList",
+        "description": "Hides all parameters passed to the executable from the Toolkit log file."
+      },
+      {
+        "name": "WorkingDirectory",
+        "description": "The working directory used for executing the process. Defaults to the directory of the file being executed. The use of UseShellExecute affects this parameter."
+      },
+      {
+        "name": "Username",
+        "description": "A username to invoke the process as. Only supported while running as the SYSTEM account."
+      },
+      {
+        "name": "UseLinkedAdminToken",
+        "description": "Use a user's linked administrative token while running the process under their context."
+      },
+      {
+        "name": "UseHighestAvailableToken",
+        "description": "Use a user's linked administrative token if it's available while running the process under their context."
+      },
+      {
+        "name": "InheritEnvironmentVariables",
+        "description": "Specifies whether the process running as a user should inherit the SYSTEM account's environment variables."
+      },
+      {
+        "name": "ExpandEnvironmentVariables",
+        "description": "Specifies whether to expand any Windows/DOS-style environment variables in the specified FilePath/ArgumentList."
+      },
+      {
+        "name": "WindowStyle",
+        "description": "Style of the window of the process executed. Options: Normal, Hidden, Maximized, Minimized. Only works for native Windows GUI applications. If the WindowStyle is set to Hidden, UseShellExecute should be set to $true. Note: Not all processes honor WindowStyle. WindowStyle is a recommendation passed to the process. They can choose to ignore it."
+      },
+      {
+        "name": "CreateNoWindow",
+        "description": "Specifies whether the process should be started with a new window to contain it."
+      },
+      {
+        "name": "StreamEncoding",
+        "description": "Specifies the encoding type to use when reading stdout/stderr. Some apps like WinGet encode using UTF8, which will corrupt if incorrectly set."
+      },
+      {
+        "name": "NoStreamLogging",
+        "description": "Don't log any available stdout/stderr data to the log file."
+      },
+      {
+        "name": "WaitForMsiExec",
+        "description": "Sometimes an EXE bootstrapper will launch an MSI install. In such cases, this variable will ensure that this function waits for the msiexec engine to become available before starting the install."
+      },
+      {
+        "name": "MsiExecWaitTime",
+        "description": "Specify the length of time in seconds to wait for the msiexec engine to become available."
+      },
+      {
+        "name": "WaitForChildProcesses",
+        "description": "Specifies whether the started process should be considered finished only when any child processes it spawns have finished also."
+      },
+      {
+        "name": "KillChildProcessesWithParent",
+        "description": "Specifies whether any child processes started by the provided executable should be closed when the provided executable closes. This is handy for application installs that open web browsers and other programs that cannot be suppressed."
+      },
+      {
+        "name": "Timeout",
+        "description": "How long to wait for the process before timing out."
+      },
+      {
+        "name": "TimeoutAction",
+        "description": "What action to take on timeout. Follows ErrorAction if not specified."
+      },
+      {
+        "name": "NoTerminateOnTimeout",
+        "description": "Indicates that the process should not be terminated on timeout. Only supported for GUI-based applications, or when -CreateNoWindow isn't specified."
+      },
+      {
+        "name": "SuccessExitCodes",
+        "description": "List of exit codes to be considered successful. Defaults to values set during ADTSession initialization, otherwise: 0"
+      },
+      {
+        "name": "RebootExitCodes",
+        "description": "List of exit codes to indicate a reboot is required. Defaults to values set during ADTSession initialization, otherwise: 1641, 3010"
+      },
+      {
+        "name": "IgnoreExitCodes",
+        "description": "List the exit codes to ignore or * to ignore all exit codes."
+      },
+      {
+        "name": "PriorityClass",
+        "description": "Specifies priority class for the process. Options: Idle, Normal, High, AboveNormal, BelowNormal, RealTime."
+      },
+      {
+        "name": "ExitOnProcessFailure",
+        "description": "Automatically closes the active deployment session via Close-ADTSession in the event the process exits with a non-success or non-ignored exit code."
+      },
+      {
+        "name": "NoWait",
+        "description": "Immediately continue after executing the process."
+      },
+      {
+        "name": "PassThru",
+        "description": "If `-NoWait` is not specified, returns an object with ExitCode, StdOut, and StdErr output from the process. If `-NoWait` is specified, returns a task that can be awaited. Note that a failed execution will only return an object if either `-ErrorAction` is set to `SilentlyContinue`/`Ignore`, or if `-IgnoreExitCodes`/`-SuccessExitCodes` are used."
+      }
+    ]
+  },
+  {
+    "name": "Start-ADTServiceAndDependencies",
+    "synopsis": "Start a Windows service and its dependencies.",
+    "description": "This function starts a specified Windows service and its dependencies. It provides options to skip starting dependent services, wait for a service to get out of a pending state, and return the service object.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Start-ADTServiceAndDependencies",
+    "parameters": [
+      {
+        "name": "Name",
+        "description": "Specify the name of the service."
+      },
+      {
+        "name": "InputObject",
+        "description": "A ServiceController object to start."
+      },
+      {
+        "name": "SkipDependentServices",
+        "description": "Choose to skip checking for and starting dependent services."
+      },
+      {
+        "name": "PendingStatusWait",
+        "description": "The amount of time to wait for a service to get out of a pending state before continuing. Default is 60 seconds."
+      },
+      {
+        "name": "PassThru",
+        "description": "Return the System.ServiceProcess.ServiceController service object."
+      }
+    ]
+  },
+  {
+    "name": "Stop-ADTServiceAndDependencies",
+    "synopsis": "Stop a Windows service and its dependencies.",
+    "description": "This function stops a specified Windows service and its dependencies. It provides options to skip stopping dependent services, wait for a service to get out of a pending state, and return the service object.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Stop-ADTServiceAndDependencies",
+    "parameters": [
+      {
+        "name": "Name",
+        "description": "Specify the name of the service."
+      },
+      {
+        "name": "InputObject",
+        "description": "A ServiceController object to stop."
+      },
+      {
+        "name": "SkipDependentServices",
+        "description": "Choose to skip checking for and stopping dependent services."
+      },
+      {
+        "name": "PendingStatusWait",
+        "description": "The amount of time to wait for a service to get out of a pending state before continuing. Default is 60 seconds."
+      },
+      {
+        "name": "PassThru",
+        "description": "Return the System.ServiceProcess.ServiceController service object."
+      }
+    ]
+  },
+  {
+    "name": "Test-ADTActiveSetup",
+    "synopsis": "",
+    "description": "",
+    "link": "",
+    "parameters": []
+  },
+  {
+    "name": "Test-ADTBattery",
+    "synopsis": "Tests whether the local machine is running on AC power or not.",
+    "description": "Tests whether the local machine is running on AC power and returns true/false. For detailed information, use the -PassThru option to get a hashtable containing various battery and power status properties.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Test-ADTBattery",
+    "parameters": [
+      {
+        "name": "PassThru",
+        "description": "Outputs an object containing the following properties: - ACPowerLineStatus - BatteryChargeStatus - BatteryLifePercent - BatterySaverEnabled - BatteryLifeRemaining - BatteryFullLifetime - IsUsingACPower - IsLaptop"
+      }
+    ]
+  },
+  {
+    "name": "Test-ADTCallerIsAdmin",
+    "synopsis": "Checks if the current user has administrative privileges.",
+    "description": "This function checks if the current user is a member of the Administrators group. It returns a boolean value indicating whether the user has administrative privileges.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Test-ADTCallerIsAdmin",
+    "parameters": []
+  },
+  {
+    "name": "Test-ADTEspActive",
+    "synopsis": "Checks if the device is currently within a device or user Enrollment Status Page (ESP) phase.",
+    "description": "This function checks if the device is currently within a device or user Enrollment Status Page (ESP) phase.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Test-ADTEspActive",
+    "parameters": []
+  },
+  {
+    "name": "Test-ADTMicrophoneInUse",
+    "synopsis": "Tests whether the device's microphone is in use.",
+    "description": "Tests whether someone is using the microphone on their device. This could be within Teams, Zoom, a game, or any other app that uses a microphone.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Test-ADTMicrophoneInUse",
+    "parameters": []
+  },
+  {
+    "name": "Test-ADTModuleInitialized",
+    "synopsis": "Checks if the ADT (PSAppDeployToolkit) module is initialized.",
+    "description": "This function checks if the ADT (PSAppDeployToolkit) module is initialized by retrieving the module data and returning the initialization status.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Test-ADTModuleInitialized",
+    "parameters": []
+  },
+  {
+    "name": "Test-ADTMSUpdates",
+    "synopsis": "Test whether a Microsoft Windows update is installed.",
+    "description": "This function checks if a specified Microsoft Windows update, identified by its KB number, is installed on the local machine. It first attempts to find the update using the Get-HotFix cmdlet and, if unsuccessful, uses a COM object to search the update history.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Test-ADTMSUpdates",
+    "parameters": [
+      {
+        "name": "KbNumber",
+        "description": "KBNumber of the update."
+      }
+    ]
+  },
+  {
+    "name": "Test-ADTMutexAvailability",
+    "synopsis": "Wait, up to a timeout value, to check if current thread is able to acquire an exclusive lock on a system mutex.",
+    "description": "A mutex can be used to serialize applications and prevent multiple instances from being opened at the same time. Wait, up to a timeout (default is 1 millisecond), for the mutex to become available for an exclusive lock.",
+    "link": "http://msdn.microsoft.com/en-us/library/aa372909(VS.85).asp",
+    "parameters": [
+      {
+        "name": "MutexName",
+        "description": "The name of the system mutex."
+      },
+      {
+        "name": "MutexWaitTime",
+        "description": "The number of milliseconds the current thread should wait to acquire an exclusive lock of a named mutex. A wait time of -1 milliseconds means to wait indefinitely. A wait time of zero does not acquire an exclusive lock but instead tests the state of the wait handle and returns immediately."
+      }
+    ]
+  },
+  {
+    "name": "Test-ADTNetworkConnection",
+    "synopsis": "Tests for an active local network connection, excluding wireless and virtual network adapters.",
+    "description": "Tests for an active local network connection, excluding wireless and virtual network adapters, by querying the Win32_NetworkAdapter WMI class. This function checks if any physical network adapter is in the 'Up' status.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Test-ADTNetworkConnection",
+    "parameters": []
+  },
+  {
+    "name": "Test-ADTOobeCompleted",
+    "synopsis": "Checks if the device's Out-of-Box Experience (OOBE) has completed or not.",
+    "description": "This function checks if the current device has completed the Out-of-Box Experience (OOBE).",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Test-ADTOobeCompleted",
+    "parameters": []
+  },
+  {
+    "name": "Test-ADTPowerPoint",
+    "synopsis": "Tests whether PowerPoint is running in either fullscreen slideshow mode or presentation mode.",
+    "description": "Tests whether someone is presenting using PowerPoint in either fullscreen slideshow mode or presentation mode. This function checks if the PowerPoint process has a window with a title that begins with \"PowerPoint Slide Show\" or \"PowerPoint-\" for non-English language systems. There is a possibility of a false positive if the PowerPoint filename starts with \"PowerPoint Slide Show\". If the previous detection method does not detect PowerPoint in fullscreen mode, it checks if PowerPoint is in Presentation Mode (only works on Windows Vista or higher).",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Test-ADTPowerPoint",
+    "parameters": []
+  },
+  {
+    "name": "Test-ADTRegistryValue",
+    "synopsis": "Test if a registry value exists.",
+    "description": "Checks a registry key path to see if it has a value with a given name. Can correctly handle cases where a value simply has an empty or null value.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Test-ADTRegistryValue",
+    "parameters": [
+      {
+        "name": "Key",
+        "description": "Path of the registry key."
+      },
+      {
+        "name": "Name",
+        "description": "Specify the name of the value to check the existence of."
+      },
+      {
+        "name": "SID",
+        "description": "The security identifier (SID) for a user. Specifying this parameter will convert a HKEY_CURRENT_USER registry key to the HKEY_USERS\\$SID format. Specify this parameter from the Invoke-ADTAllUsersRegistryAction function to read/edit HKCU registry settings for all users on the system."
+      },
+      {
+        "name": "Wow6432Node",
+        "description": "Specify this switch to check the 32-bit registry (Wow6432Node) on 64-bit systems."
+      }
+    ]
+  },
+  {
+    "name": "Test-ADTServiceExists",
+    "synopsis": "Check to see if a service exists.",
+    "description": "Check to see if a service exists. The UseCIM switch can be used in conjunction with PassThru to return WMI objects for PSADT v3.x compatibility, however, this method fails in Windows Sandbox.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Test-ADTServiceExists",
+    "parameters": [
+      {
+        "name": "Name",
+        "description": "Specify the name of the service. Note: Service name can be found by executing \"Get-Service | Format-Table -AutoSize -Wrap\" or by using the properties screen of a service in services.msc."
+      },
+      {
+        "name": "UseCIM",
+        "description": "Use CIM/WMI to check for the service. This is useful for compatibility with PSADT v3.x."
+      },
+      {
+        "name": "PassThru",
+        "description": "Return the WMI service object. To see all the properties use: Test-ADTServiceExists -Name 'spooler' -PassThru | Get-Member"
+      }
+    ]
+  },
+  {
+    "name": "Test-ADTSessionActive",
+    "synopsis": "Checks if there is an active ADT session.",
+    "description": "This function checks if there is an active ADT (App Deploy Toolkit) session by retrieving the module data and returning the count of active sessions.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Test-ADTSessionActive",
+    "parameters": []
+  },
+  {
+    "name": "Test-ADTUserIsBusy",
+    "synopsis": "Tests whether the device's microphone is in use, the user has manually turned on presentation mode, or PowerPoint is running in either fullscreen slideshow mode or presentation mode.",
+    "description": "Tests whether the device's microphone is in use, the user has manually turned on presentation mode, or PowerPoint is running in either fullscreen slideshow mode or presentation mode.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Test-ADTUserIsBusy",
+    "parameters": []
+  },
+  {
+    "name": "Test-NamedAttributeArgumentAst",
+    "synopsis": "",
+    "description": "",
+    "link": "",
+    "parameters": []
+  },
+  {
+    "name": "Unblock-ADTAppExecution",
+    "synopsis": "Unblocks the execution of applications performed by the Block-ADTAppExecution function.",
+    "description": "This function is called by the Close-ADTSession function. It undoes the actions performed by Block-ADTAppExecution, allowing previously blocked applications to execute.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Unblock-ADTAppExecution",
+    "parameters": [
+      {
+        "name": "Tasks",
+        "description": "Specify the scheduled tasks to unblock."
+      }
+    ]
+  },
+  {
+    "name": "Uninstall-ADTApplication",
+    "synopsis": "Removes one or more applications specified by name, filter script, or InstalledApplication object from Get-ADTApplication.",
+    "description": "Removes one or more applications specified by name, filter script, or InstalledApplication object from Get-ADTApplication. Enumerates the registry for installed applications via Get-ADTApplication, matching the specified application name and uninstalls that application using its uninstall string, with the ability to specify additional uninstall parameters also.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Uninstall-ADTApplication",
+    "parameters": [
+      {
+        "name": "InstalledApplication",
+        "description": "Specifies the [PSADT.Types.InstalledApplication] object to remove. This parameter is typically used when piping Get-ADTApplication to this function."
+      },
+      {
+        "name": "Name",
+        "description": "The name of the application to retrieve information for. Performs a contains match on the application display name by default."
+      },
+      {
+        "name": "NameMatch",
+        "description": "Specifies the type of match to perform on the application name. Valid values are 'Contains', 'Exact', 'Wildcard', and 'Regex'. The default value is 'Contains'."
+      },
+      {
+        "name": "ProductCode",
+        "description": "The product code of the application to retrieve information for."
+      },
+      {
+        "name": "ApplicationType",
+        "description": "Specifies the type of application to remove. Valid values are 'All', 'MSI', and 'EXE'. The default value is 'All'."
+      },
+      {
+        "name": "IncludeUpdatesAndHotfixes",
+        "description": "Include matches against updates and hotfixes in results."
+      },
+      {
+        "name": "FilterScript",
+        "description": "A script used to filter the results as they're processed."
+      },
+      {
+        "name": "ArgumentList",
+        "description": "Overrides the default MSI parameters specified in the config.psd1 file, or the parameters found in QuietUninstallString/UninstallString for EXE applications."
+      },
+      {
+        "name": "AdditionalArgumentList",
+        "description": "Adds to the default parameters specified in the config.psd1 file, or the parameters found in QuietUninstallString/UninstallString for EXE applications."
+      },
+      {
+        "name": "SecureArgumentList",
+        "description": "Hides all parameters passed to the executable from the Toolkit log file."
+      },
+      {
+        "name": "LoggingOptions",
+        "description": "Overrides the default MSI logging options specified in the config.psd1 file. Default options are: \"/L*v\"."
+      },
+      {
+        "name": "LogFileName",
+        "description": "Overrides the default log file name for MSI applications. The default log file name is generated from the MSI file name. If LogFileName does not end in .log, it will be automatically appended. For uninstallations, by default the product code is resolved to the DisplayName and version of the application."
+      },
+      {
+        "name": "WaitForChildProcesses",
+        "description": "Specifies whether the started process should be considered finished only when any child processes it spawns have finished also."
+      },
+      {
+        "name": "KillChildProcessesWithParent",
+        "description": "Specifies whether any child processes started by the provided executable should be closed when the provided executable closes. This is handy for application installs that open web browsers and other programs that cannot be suppressed."
+      },
+      {
+        "name": "SuccessExitCodes",
+        "description": "List of exit codes to be considered successful. Defaults to values set during ADTSession initialization, otherwise: 0"
+      },
+      {
+        "name": "RebootExitCodes",
+        "description": "List of exit codes to indicate a reboot is required. Defaults to values set during ADTSession initialization, otherwise: 1641, 3010"
+      },
+      {
+        "name": "IgnoreExitCodes",
+        "description": "List the exit codes to ignore or * to ignore all exit codes. Where possible, please use `-SuccessExitCodes` and/or `-RebootExitCodes` instead."
+      },
+      {
+        "name": "ExitOnProcessFailure",
+        "description": "Automatically closes the active deployment session via Close-ADTSession in the event the process exits with a non-success or non-ignored exit code."
+      },
+      {
+        "name": "PassThru",
+        "description": "Returns a PSADT.Types.ProcessResult object, providing the ExitCode, StdOut, and StdErr output from the uninstallation."
+      }
+    ]
+  },
+  {
+    "name": "Unregister-ADTDll",
+    "synopsis": "Unregister a DLL file.",
+    "description": "Unregister a DLL file using regsvr32.exe. This function takes the path to the DLL file and attempts to unregister it using the regsvr32.exe utility.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Unregister-ADTDll",
+    "parameters": [
+      {
+        "name": "FilePath",
+        "description": "Path to the DLL file."
+      }
+    ]
+  },
+  {
+    "name": "Update-ADTDeferHistory",
+    "synopsis": "",
+    "description": "",
+    "link": "",
+    "parameters": []
+  },
+  {
+    "name": "Update-ADTDesktop",
+    "synopsis": "Refresh the Windows Explorer Shell, which causes the desktop icons and the environment variables to be reloaded.",
+    "description": "This function refreshes the Windows Explorer Shell, causing the desktop icons and environment variables to be reloaded. This can be useful after making changes that affect the desktop or environment variables, ensuring that the changes are reflected immediately.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Update-ADTDesktop",
+    "parameters": []
+  },
+  {
+    "name": "Update-ADTEnvironmentPsProvider",
+    "synopsis": "Updates the environment variables for the current PowerShell session with any environment variable changes that may have occurred during script execution.",
+    "description": "Environment variable changes that take place during script execution are not visible to the current PowerShell session. Use this function to refresh the current PowerShell session with all environment variable settings.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Update-ADTEnvironmentPsProvider",
+    "parameters": [
+      {
+        "name": "LoadLoggedOnUserEnvironmentVariables",
+        "description": "If script is running in SYSTEM context, this option allows loading environment variables from the active console user. If no console user exists but users are logged in, such as on terminal servers, then the first logged-in non-console user."
+      }
+    ]
+  },
+  {
+    "name": "Update-ADTGroupPolicy",
+    "synopsis": "Performs a gpupdate command to refresh Group Policies on the local machine.",
+    "description": "This function performs a gpupdate command to refresh Group Policies on the local machine. It updates both Computer and User policies by forcing a refresh using the gpupdate.exe utility.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Update-ADTGroupPolicy",
+    "parameters": []
+  },
+  {
+    "name": "Update-ADTImportedDataValues",
+    "synopsis": "",
+    "description": "",
+    "link": "",
+    "parameters": []
+  },
+  {
+    "name": "Write-ADTLogEntry",
+    "synopsis": "Write messages to a log file in CMTrace.exe compatible format or Legacy text file format.",
+    "description": "Write messages to a log file in CMTrace.exe compatible format or Legacy text file format and optionally display in the console. This function supports different severity levels and can be used to log debug messages if required.",
+    "link": "https://psappdeploytoolkit.com/docs/reference/functions/Write-ADTLogEntry",
+    "parameters": [
+      {
+        "name": "Message",
+        "description": "The message to write to the log file or output to the console."
+      },
+      {
+        "name": "Severity",
+        "description": "Defines message type. When writing to console or CMTrace.exe log format, it allows highlighting of message type."
+      },
+      {
+        "name": "Source",
+        "description": "The source of the message being logged."
+      },
+      {
+        "name": "ScriptSection",
+        "description": "The heading for the portion of the script that is being executed."
+      },
+      {
+        "name": "LogType",
+        "description": "Choose whether to write a CMTrace.exe compatible log file or a Legacy text log file."
+      },
+      {
+        "name": "LogFileDirectory",
+        "description": "Set the directory where the log file will be saved."
+      },
+      {
+        "name": "LogFileName",
+        "description": "Set the name of the log file."
+      },
+      {
+        "name": "HostLogStream",
+        "description": "Controls how the log entry is written to the console window."
+      },
+      {
+        "name": "PassThru",
+        "description": "Return the message that was passed to the function."
+      },
+      {
+        "name": "DebugMessage",
+        "description": "Specifies that the message is a debug message. Debug messages only get logged if -LogDebugMessage is set to $true."
+      }
+    ]
+  }
+]

--- a/src/js/editor.js
+++ b/src/js/editor.js
@@ -1,62 +1,199 @@
-// Modern command editor with filtering and click-to-add
+// Modern command explorer with parameter details
 (() => {
   const builderEl = document.getElementById('builder');
   if (!builderEl) return;
 
   const boxesEl = document.getElementById('command-boxes');
+  const detailEl = document.getElementById('command-detail');
   const editorEl = document.getElementById('editor-area');
   const searchEl = document.getElementById('command-search');
 
-  // Insert command text into editor
-  function insertCommand(cmd){
+  let commands = [];
+  let filtered = [];
+  let activeName = '';
+
+  function insertCommand(cmd) {
+    if (!editorEl) return;
     const current = editorEl.textContent;
     editorEl.textContent = current ? `${current}\n${cmd}` : cmd;
   }
 
-  // Allow dropping commands
-  editorEl.addEventListener('dragover', e => e.preventDefault());
-  editorEl.addEventListener('drop', e => {
-    e.preventDefault();
-    const text = e.dataTransfer.getData('text/plain');
-    if (text) insertCommand(text);
-  });
+  function highlightActive(name) {
+    activeName = name;
+    if (!boxesEl) return;
+    boxesEl.querySelectorAll('.cmd-box').forEach((box) => {
+      const isActive = box.dataset.command === name;
+      box.classList.toggle('active', isActive);
+      box.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+    });
+  }
 
-  // Render command boxes
-  function render(list){
+  function renderEmptyDetail(message) {
+    if (!detailEl) return;
+    detailEl.innerHTML = '';
+    detailEl.classList.add('empty');
+    const p = document.createElement('p');
+    p.textContent = message;
+    detailEl.appendChild(p);
+  }
+
+  function showCommandDetail(cmd) {
+    if (!detailEl) return;
+    highlightActive(cmd.name);
+    detailEl.classList.remove('empty');
+    detailEl.innerHTML = '';
+
+    const header = document.createElement('div');
+    header.className = 'cmd-detail-header';
+
+    const titleWrap = document.createElement('div');
+    titleWrap.className = 'cmd-detail-title';
+    const title = document.createElement('h3');
+    title.textContent = cmd.name;
+    titleWrap.appendChild(title);
+    if (cmd.synopsis) {
+      const synopsis = document.createElement('p');
+      synopsis.className = 'cmd-detail-synopsis';
+      synopsis.textContent = cmd.synopsis;
+      titleWrap.appendChild(synopsis);
+    }
+    header.appendChild(titleWrap);
+
+    const actions = document.createElement('div');
+    actions.className = 'cmd-detail-actions';
+    const addBtn = document.createElement('button');
+    addBtn.type = 'button';
+    addBtn.className = 'btn btn-ghost cmd-detail-add';
+    addBtn.textContent = 'Add to editor';
+    addBtn.addEventListener('click', () => insertCommand(cmd.name));
+    actions.appendChild(addBtn);
+    if (cmd.link) {
+      const link = document.createElement('a');
+      link.href = cmd.link;
+      link.target = '_blank';
+      link.rel = 'noreferrer';
+      link.className = 'cmd-detail-link';
+      link.textContent = 'View documentation';
+      actions.appendChild(link);
+    }
+    header.appendChild(actions);
+    detailEl.appendChild(header);
+
+    if (cmd.parameters && cmd.parameters.length) {
+      const list = document.createElement('div');
+      list.className = 'cmd-param-list';
+      cmd.parameters.forEach((param) => {
+        const item = document.createElement('div');
+        item.className = 'cmd-param';
+
+        const nameRow = document.createElement('div');
+        nameRow.className = 'cmd-param-header';
+        const nameEl = document.createElement('code');
+        nameEl.className = 'cmd-param-name';
+        nameEl.textContent = `-${param.name}`;
+        nameRow.appendChild(nameEl);
+        item.appendChild(nameRow);
+
+        if (param.description) {
+          const desc = document.createElement('p');
+          desc.className = 'cmd-param-desc';
+          desc.textContent = param.description;
+          item.appendChild(desc);
+        }
+        list.appendChild(item);
+      });
+      detailEl.appendChild(list);
+    } else {
+      const noParams = document.createElement('p');
+      noParams.className = 'cmd-no-params';
+      noParams.textContent = 'This command does not document any parameters.';
+      detailEl.appendChild(noParams);
+    }
+  }
+
+  function renderCommands(list) {
+    if (!boxesEl) return;
     boxesEl.innerHTML = '';
-    list.forEach(cmd => {
+    if (!list.length) {
+      const msg = document.createElement('div');
+      msg.className = 'cmd-empty';
+      msg.textContent = 'No commands found.';
+      boxesEl.appendChild(msg);
+      highlightActive('');
+      renderEmptyDetail('Select a command to view parameters.');
+      return;
+    }
+    list.forEach((cmd) => {
       const box = document.createElement('div');
-      box.className = 'cmd-box';
-      box.textContent = cmd;
+      box.className = 'cmd-box' + (cmd.name === activeName ? ' active' : '');
+      box.textContent = cmd.name;
       box.draggable = true;
       box.tabIndex = 0;
-      box.setAttribute('role','button');
-      box.addEventListener('dragstart', e => e.dataTransfer.setData('text/plain', cmd));
-      box.addEventListener('click', () => insertCommand(cmd));
-      box.addEventListener('keydown', e => {
-        if (e.key === 'Enter') { e.preventDefault(); insertCommand(cmd); }
+      box.dataset.command = cmd.name;
+      box.setAttribute('role', 'button');
+      box.setAttribute('aria-pressed', cmd.name === activeName ? 'true' : 'false');
+      box.addEventListener('dragstart', (e) => {
+        e.dataTransfer.setData('text/plain', cmd.name);
+      });
+      box.addEventListener('click', () => {
+        showCommandDetail(cmd);
+      });
+      box.addEventListener('dblclick', (e) => {
+        e.preventDefault();
+        insertCommand(cmd.name);
+      });
+      box.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          showCommandDetail(cmd);
+        } else if (e.key === 'Insert') {
+          insertCommand(cmd.name);
+        }
       });
       boxesEl.appendChild(box);
     });
   }
 
-  // Load commands and set up filtering
-  async function init(){
-    try {
-      const res = await fetch('psadt/psadt-cmds.txt');
-      const txt = await res.text();
-      const cmds = txt.split(/\r?\n/).map(s => s.trim()).filter(Boolean);
-      render(cmds);
-      if (searchEl){
-        searchEl.addEventListener('input', () => {
-          const term = searchEl.value.trim().toLowerCase();
-          const filtered = cmds.filter(c => c.toLowerCase().includes(term));
-          render(filtered);
+  function applyFilter(term) {
+    const normalized = term.trim().toLowerCase();
+    filtered = !normalized
+      ? commands.slice()
+      : commands.filter((cmd) => {
+          const haystack = `${cmd.name} ${cmd.synopsis || ''} ${cmd.description || ''}`.toLowerCase();
+          return haystack.includes(normalized);
         });
+    if (activeName && !filtered.some((cmd) => cmd.name === activeName)) {
+      activeName = '';
+      renderEmptyDetail('Select a command to view parameters.');
+    }
+    renderCommands(filtered);
+  }
+
+  if (editorEl) {
+    editorEl.addEventListener('dragover', (e) => e.preventDefault());
+    editorEl.addEventListener('drop', (e) => {
+      e.preventDefault();
+      const text = e.dataTransfer.getData('text/plain');
+      if (text) insertCommand(text);
+    });
+  }
+
+  async function init() {
+    if (!boxesEl) return;
+    try {
+      const res = await fetch('src/data/command-metadata.json');
+      const data = await res.json();
+      commands = Array.isArray(data) ? data : [];
+      filtered = commands.slice();
+      renderCommands(filtered);
+      renderEmptyDetail('Select a command to view parameters.');
+      if (searchEl) {
+        searchEl.addEventListener('input', () => applyFilter(searchEl.value || ''));
       }
-    } catch (err){
+    } catch (err) {
       const msg = document.createElement('div');
-      msg.textContent = 'Failed to load commands';
+      msg.className = 'cmd-empty';
+      msg.textContent = 'Failed to load commands.';
       boxesEl.appendChild(msg);
       console.error(err);
     }
@@ -64,4 +201,3 @@
 
   init();
 })();
-

--- a/styles.css
+++ b/styles.css
@@ -908,6 +908,99 @@ textarea {
   border-color: color-mix(in srgb, var(--color-accent) 25%, var(--color-border) 75%);
 }
 
+.cmd-box.active {
+  background: color-mix(in srgb, var(--color-accent) 18%, var(--color-surface) 82%);
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+  cursor: pointer;
+}
+
+.cmd-empty {
+  padding: var(--space-sm);
+  color: var(--color-muted);
+  font-size: var(--fs-300);
+}
+
+.cmd-detail {
+  margin-top: var(--space-md);
+  padding-top: var(--space-md);
+  border-top: 1px solid var(--color-border);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.cmd-detail.empty {
+  color: var(--color-muted);
+}
+
+.cmd-detail-header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: var(--space-sm);
+}
+
+.cmd-detail-title {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2xs);
+}
+
+.cmd-detail-synopsis {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: var(--fs-300);
+}
+
+.cmd-detail-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-xs);
+}
+
+.cmd-detail-link {
+  font-size: var(--fs-300);
+  color: var(--color-accent);
+  text-decoration: none;
+}
+
+.cmd-detail-link:hover {
+  text-decoration: underline;
+}
+
+.cmd-param-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.cmd-param {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-sm);
+  background: color-mix(in srgb, var(--color-surface) 92%, var(--color-bg) 8%);
+}
+
+.cmd-param-name {
+  font-family: var(--font-mono);
+  font-weight: 600;
+  font-size: var(--fs-300);
+}
+
+.cmd-param-desc {
+  margin: var(--space-2xs) 0 0 0;
+  font-size: var(--fs-300);
+  line-height: 1.45;
+}
+
+.cmd-no-params {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: var(--fs-300);
+}
+
 .cmd-editor {
   min-height: 6rem;
   padding: var(--space-md);


### PR DESCRIPTION
## Summary
- add a build script to extract PSADT command documentation into JSON metadata
- update the command builder UI to load the metadata, show command details, and keep editing controls
- style the command detail view and register an npm script for regenerating metadata

## Testing
- npm run lint
- npm run build:commands

------
https://chatgpt.com/codex/tasks/task_e_68cbd078a6ec8324966b7157ec0fb896