### PR TITLE
Add manifest and service worker with offline opt-out

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,22 @@ pwsh ./make.ps1 -Install
 ```
 This installs dependencies, runs JS tests and Pester tests.
 
+## Offline caching & manifest
+
+The site now exposes a Progressive Web App manifest (`manifest.json`) and a
+service worker (`sw.js`) that precaches core assets (HTML, styles, telemetry
+scripts, JSON data, and icons) for offline access. Users can control telemetry
+and caching independently via the toggles in the header: turning off caching
+persists a preference in `localStorage`, unregisters existing service workers,
+and clears `psadt-cache-*` entries.
+
+### Cache busting
+
+Static updates should bump `CACHE_VERSION` in `sw.js`. Doing so creates a new
+cache namespace (`psadt-cache-<version>`), allowing the activation handler to
+discard outdated entries while keeping the offline toggle honouring the stored
+preference.
+
 ## Project Layout
 
 - `src/js` - browser JavaScript modules

--- a/assets/app-icon-maskable.svg
+++ b/assets/app-icon-maskable.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <linearGradient id="maskGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#175beb" />
+      <stop offset="100%" stop-color="#0f172a" />
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="128" fill="url(#maskGrad)" />
+  <g fill="#fff" font-family="'Segoe UI', sans-serif" font-weight="700">
+    <text font-size="200" x="50%" y="58%" dominant-baseline="middle" text-anchor="middle">CC</text>
+  </g>
+</svg>

--- a/assets/app-icon.svg
+++ b/assets/app-icon.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#175beb" />
+      <stop offset="100%" stop-color="#0f172a" />
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="96" fill="url(#grad)" />
+  <g fill="#fff" font-family="'Segoe UI', sans-serif" font-weight="700">
+    <text font-size="176" x="50%" y="55%" dominant-baseline="middle" text-anchor="middle">PS</text>
+    <text font-size="112" x="50%" y="72%" dominant-baseline="middle" text-anchor="middle">ADT</text>
+  </g>
+</svg>

--- a/index.html
+++ b/index.html
@@ -7,7 +7,10 @@
       http-equiv="Content-Security-Policy"
       content="default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:"
     />
+    <meta name="theme-color" content="#0f172a" />
     <title>Cloudcook PSADT Helper</title>
+    <link rel="icon" type="image/svg+xml" href="assets/app-icon.svg" />
+    <link rel="manifest" href="manifest.json" />
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
@@ -69,9 +72,14 @@
               <span>Function mapping</span>
             </a>
           </nav>
-          <label for="telemetry-toggle" class="telemetry-toggle"
-            ><input type="checkbox" id="telemetry-toggle" /> Enable telemetry</label
-          >
+          <div class="header-toggles">
+            <label for="telemetry-toggle" class="telemetry-toggle"
+              ><input type="checkbox" id="telemetry-toggle" /> Enable telemetry</label
+            >
+            <label for="cache-toggle" class="telemetry-toggle"
+              ><input type="checkbox" id="cache-toggle" /> Enable offline cache</label
+            >
+          </div>
         </div>
       </div>
     </header>
@@ -443,6 +451,7 @@
     <script src="src/js/commands.js"></script>
     <script src="src/js/state.js"></script>
     <script src="src/js/variables.js"></script>
+    <script src="src/js/sw-registration.js"></script>
     <script src="src/js/main.js"></script>
     <script src="src/js/editor.js"></script>
   </body>

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,24 @@
+{
+  "name": "Cloudcook PSADT Helper",
+  "short_name": "PSADT Helper",
+  "description": "Curated tooling for building PSAppDeployToolkit deployment scripts.",
+  "start_url": ".",
+  "scope": ".",
+  "display": "standalone",
+  "background_color": "#0f172a",
+  "theme_color": "#175beb",
+  "lang": "en-US",
+  "icons": [
+    {
+      "src": "assets/app-icon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml"
+    },
+    {
+      "src": "assets/app-icon-maskable.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "maskable"
+    }
+  ]
+}

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -30,10 +30,28 @@
   const bgSwatchesEl = document.getElementById('bg-swatches');
   const modeSel = document.getElementById('color-mode');
   const telemetryToggle = document.getElementById('telemetry-toggle');
+  const cacheToggle = document.getElementById('cache-toggle');
   if (telemetryToggle) {
     telemetryToggle.addEventListener('change', (e) =>
       setTelemetry(e.target.checked),
     );
+  }
+  if (cacheToggle && window.psadtServiceWorker) {
+    cacheToggle.checked = window.psadtServiceWorker.shouldEnable();
+    if (!('serviceWorker' in navigator)) {
+      cacheToggle.disabled = true;
+      if (cacheToggle.parentElement) {
+        cacheToggle.parentElement.setAttribute(
+          'title',
+          'Offline cache requires service worker support.',
+        );
+      }
+    }
+    cacheToggle.addEventListener('change', (e) => {
+      window.psadtServiceWorker
+        .setPreference(e.target.checked)
+        .catch((error) => console.error(error));
+    });
   }
   document.querySelectorAll('img[data-hide-on-error]').forEach((img) => {
     img.addEventListener('error', () => img.classList.add('hidden'));

--- a/src/js/sw-registration.js
+++ b/src/js/sw-registration.js
@@ -1,0 +1,104 @@
+(() => {
+  const SW_PATH = 'sw.js';
+  const PREF_KEY = 'psadt-cache-disabled';
+  const CACHE_PREFIX = 'psadt-cache-';
+
+  const hasServiceWorkerSupport = () =>
+    typeof navigator !== 'undefined' && 'serviceWorker' in navigator;
+
+  const logError = (error) => {
+    if (typeof console !== 'undefined' && console.error) {
+      console.error('[psadt-helper] Service worker error:', error);
+    }
+  };
+
+  async function register() {
+    if (!hasServiceWorkerSupport()) return null;
+    try {
+      return await navigator.serviceWorker.register(SW_PATH);
+    } catch (error) {
+      logError(error);
+      return null;
+    }
+  }
+
+  async function clearCaches() {
+    if (typeof caches === 'undefined') return;
+    try {
+      const keys = await caches.keys();
+      await Promise.all(
+        keys
+          .filter((key) => key.startsWith(CACHE_PREFIX))
+          .map((key) => caches.delete(key)),
+      );
+    } catch (error) {
+      logError(error);
+    }
+  }
+
+  async function unregister() {
+    if (!hasServiceWorkerSupport()) return;
+    try {
+      const registrations = await navigator.serviceWorker.getRegistrations();
+      await Promise.all(registrations.map((registration) => registration.unregister()));
+    } catch (error) {
+      logError(error);
+    }
+    await clearCaches();
+  }
+
+  const shouldEnable = () => {
+    try {
+      return localStorage.getItem(PREF_KEY) !== 'true';
+    } catch (error) {
+      logError(error);
+      return true;
+    }
+  };
+
+  const setPreference = async (enabled) => {
+    try {
+      localStorage.setItem(PREF_KEY, enabled ? 'false' : 'true');
+    } catch (error) {
+      logError(error);
+    }
+    if (enabled) {
+      await register();
+    } else {
+      await unregister();
+    }
+  };
+
+  const init = async () => {
+    if (!shouldEnable()) {
+      await unregister();
+      return;
+    }
+    await register();
+  };
+
+  if (typeof window !== 'undefined') {
+    window.psadtServiceWorker = {
+      SW_PATH,
+      PREF_KEY,
+      register,
+      unregister,
+      shouldEnable,
+      setPreference,
+      init,
+    };
+    init();
+  }
+
+  if (typeof module !== 'undefined') {
+    module.exports = {
+      SW_PATH,
+      PREF_KEY,
+      register,
+      unregister,
+      shouldEnable,
+      setPreference,
+      init,
+    };
+  }
+})();

--- a/styles.css
+++ b/styles.css
@@ -357,6 +357,13 @@ ul {
     box-shadow var(--transition-base), color var(--transition-fast);
 }
 
+.header-toggles {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
+  justify-content: flex-end;
+}
+
 .telemetry-toggle:hover {
   border-color: color-mix(in srgb, var(--color-accent) 45%, var(--color-border) 55%);
   color: var(--color-text);

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,95 @@
+const CACHE_VERSION = 'v1';
+const CACHE_PREFIX = 'psadt-cache-';
+const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
+const PRECACHE_URLS = [
+  '/',
+  'index.html',
+  'styles.css',
+  'manifest.json',
+  'assets/cloudcook-logo.png',
+  'assets/app-icon.svg',
+  'assets/app-icon-maskable.svg',
+  'src/js/telemetry.js',
+  'src/js/legacy-mapping.js',
+  'src/js/commands.js',
+  'src/js/state.js',
+  'src/js/variables.js',
+  'src/js/sw-registration.js',
+  'src/js/main.js',
+  'src/js/editor.js',
+  'src/data/command-metadata.json',
+  'src/data/legacy-mapping.json',
+];
+
+const swGlobal = typeof self !== 'undefined' ? self : undefined;
+
+function isSameOrigin(requestUrl) {
+  if (!swGlobal || !swGlobal.location) return true;
+  try {
+    const request = new URL(requestUrl, swGlobal.location.href);
+    return request.origin === swGlobal.location.origin;
+  } catch (error) {
+    return false;
+  }
+}
+
+async function precache() {
+  const cache = await caches.open(CACHE_NAME);
+  await cache.addAll(PRECACHE_URLS);
+}
+
+async function handleActivate() {
+  const keys = await caches.keys();
+  await Promise.all(
+    keys
+      .filter((key) => key.startsWith(CACHE_PREFIX) && key !== CACHE_NAME)
+      .map((key) => caches.delete(key)),
+  );
+}
+
+async function fetchFromCache(event) {
+  const request = event.request;
+  if (request.method !== 'GET' || !isSameOrigin(request.url)) {
+    return fetch(request);
+  }
+  const cache = await caches.open(CACHE_NAME);
+  const cached = await cache.match(request, { ignoreSearch: true });
+  if (cached) {
+    return cached;
+  }
+  const response = await fetch(request);
+  cache.put(request, response.clone());
+  return response;
+}
+
+if (swGlobal) {
+  swGlobal.addEventListener('install', (event) => {
+    event.waitUntil(
+      precache()
+        .then(() => swGlobal.skipWaiting && swGlobal.skipWaiting())
+        .catch((error) => console.error('[psadt-helper] precache failed', error)),
+    );
+  });
+
+  swGlobal.addEventListener('activate', (event) => {
+    event.waitUntil(
+      handleActivate()
+        .then(() => swGlobal.clients && swGlobal.clients.claim && swGlobal.clients.claim())
+        .catch((error) => console.error('[psadt-helper] activate failed', error)),
+    );
+  });
+
+  swGlobal.addEventListener('fetch', (event) => {
+    event.respondWith(fetchFromCache(event));
+  });
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = {
+    CACHE_NAME,
+    CACHE_PREFIX,
+    CACHE_VERSION,
+    PRECACHE_URLS,
+    isSameOrigin,
+  };
+}

--- a/tests/js/sw.test.js
+++ b/tests/js/sw.test.js
@@ -1,0 +1,72 @@
+const path = require('path');
+
+const createMemoryStorage = () => {
+  let store = {};
+  return {
+    getItem: (key) => (key in store ? store[key] : null),
+    setItem: (key, value) => {
+      store[key] = String(value);
+    },
+    removeItem: (key) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+  };
+};
+
+describe('service worker registration bootstrap', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    global.localStorage = createMemoryStorage();
+    global.navigator = {
+      serviceWorker: {
+        register: jest.fn().mockResolvedValue({}),
+        getRegistrations: jest.fn().mockResolvedValue([]),
+      },
+    };
+    global.window = {
+      navigator: global.navigator,
+    };
+    global.caches = {
+      keys: jest.fn().mockResolvedValue([]),
+      delete: jest.fn().mockResolvedValue(true),
+    };
+  });
+
+  afterEach(() => {
+    delete global.localStorage;
+    delete global.navigator;
+    delete global.window;
+    delete global.caches;
+  });
+
+  it('registers the service worker at the root sw.js path', async () => {
+    await require(path.join('../../src/js/sw-registration.js'));
+    await Promise.resolve();
+    expect(global.navigator.serviceWorker.register).toHaveBeenCalledWith('sw.js');
+  });
+});
+
+describe('service worker precache list', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  it('includes critical application shell assets', () => {
+    const { PRECACHE_URLS } = require(path.join('../../sw.js'));
+    expect(PRECACHE_URLS).toEqual(
+      expect.arrayContaining([
+        'index.html',
+        'styles.css',
+        'src/js/main.js',
+        'src/js/sw-registration.js',
+        'src/data/command-metadata.json',
+        'src/data/legacy-mapping.json',
+        'assets/cloudcook-logo.png',
+        'assets/app-icon.svg',
+      ]),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add a web app manifest, svg icons, and theme-color metadata along with an offline cache toggle in the header
- implement a service worker plus registration helper that precaches the application shell and respects an opt-out preference
- document cache versioning guidance and cover the registration path and precache list with Jest tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cbd75a21a08324b60efa0d2bfd7402