### PR TITLE
Enhance builder parameter controls and metadata

### DIFF
--- a/scripts/build-command-metadata.js
+++ b/scripts/build-command-metadata.js
@@ -2,8 +2,20 @@
 const fs = require('fs');
 const path = require('path');
 
-const sourcePath = path.join(__dirname, '..', 'psadt', 'PSAppDeployToolkit', 'PSAppDeployToolkit.psm1');
-const outputPath = path.join(__dirname, '..', 'src', 'data', 'command-metadata.json');
+const sourcePath = path.join(
+  __dirname,
+  '..',
+  'psadt',
+  'PSAppDeployToolkit',
+  'PSAppDeployToolkit.psm1'
+);
+const outputPath = path.join(
+  __dirname,
+  '..',
+  'src',
+  'data',
+  'command-metadata.json'
+);
 
 function normalizeText(block) {
   return block
@@ -15,6 +27,14 @@ function normalizeText(block) {
     .trim();
 }
 
+function stripQuotes(value) {
+  if (!value) return '';
+  const trimmed = value.trim();
+  const match = trimmed.match(/^(["'])([\s\S]*)\1$/);
+  if (!match) return trimmed;
+  return match[2];
+}
+
 function parseCommentBlock(raw) {
   if (!raw) {
     return {
@@ -22,23 +42,41 @@ function parseCommentBlock(raw) {
       description: '',
       link: '',
       parameters: [],
+      examples: [],
     };
   }
-  const body = raw
-    .replace(/^\s*<#/, '')
-    .replace(/#>\s*$/, '');
-  const synopsisMatch = body.match(/\.SYNOPSIS\s*\r?\n([\s\S]*?)(?=\r?\n\s*\.[A-Z]|$)/);
-  const descriptionMatch = body.match(/\.DESCRIPTION\s*\r?\n([\s\S]*?)(?=\r?\n\s*\.[A-Z]|$)/);
-  const linkMatch = body.match(/\.LINK\s*\r?\n([\s\S]*?)(?=\r?\n\s*\.[A-Z]|$)/);
+  const body = raw.replace(/^\s*<#/, '').replace(/#>\s*$/, '');
+  const synopsisMatch = body.match(
+    /\.SYNOPSIS\s*\r?\n([\s\S]*?)(?=\r?\n\s*\.[A-Z]|$)/
+  );
+  const descriptionMatch = body.match(
+    /\.DESCRIPTION\s*\r?\n([\s\S]*?)(?=\r?\n\s*\.[A-Z]|$)/
+  );
+  const linkMatch = body.match(
+    /\.LINK\s*\r?\n([\s\S]*?)(?=\r?\n\s*\.[A-Z]|$)/
+  );
 
   const parameters = [];
   const paramRegex = /\.PARAMETER\s+([^\r\n]+)\r?\n([\s\S]*?)(?=\r?\n\s*\.[A-Z]|\r?\n\s*#>|$)/g;
-  let match;
-  while ((match = paramRegex.exec(body)) !== null) {
-    const name = match[1].trim();
-    const desc = normalizeText(match[2]);
+  let paramMatch;
+  while ((paramMatch = paramRegex.exec(body)) !== null) {
+    const name = paramMatch[1].trim();
+    const desc = normalizeText(paramMatch[2]);
     if (name) {
       parameters.push({ name, description: desc });
+    }
+  }
+
+  const examples = [];
+  const exampleRegex = /\.EXAMPLE\s*\r?\n([\s\S]*?)(?=\r?\n\s*\.[A-Z]|\r?\n\s*#>|$)/g;
+  let exampleMatch;
+  while ((exampleMatch = exampleRegex.exec(body)) !== null) {
+    const lines = exampleMatch[1]
+      .split(/\r?\n/)
+      .map(line => line.trim())
+      .filter(Boolean);
+    if (lines.length) {
+      examples.push(lines[0]);
     }
   }
 
@@ -47,7 +85,139 @@ function parseCommentBlock(raw) {
     description: descriptionMatch ? normalizeText(descriptionMatch[1]) : '',
     link: linkMatch ? normalizeText(linkMatch[1]) : '',
     parameters,
+    examples,
   };
+}
+
+function extractParamBlock(section) {
+  const paramIndex = section.indexOf('param');
+  if (paramIndex === -1) {
+    return '';
+  }
+  const openIndex = section.indexOf('(', paramIndex);
+  if (openIndex === -1) {
+    return '';
+  }
+  let depth = 0;
+  for (let i = openIndex; i < section.length; i += 1) {
+    const char = section[i];
+    if (char === '(') {
+      depth += 1;
+    } else if (char === ')') {
+      depth -= 1;
+      if (depth === 0) {
+        return section.slice(openIndex + 1, i);
+      }
+    }
+  }
+  return '';
+}
+
+function isLikelyTypeAttribute(content) {
+  if (!content) return false;
+  const normalized = content.trim();
+  if (/^Parameter/i.test(normalized)) return false;
+  if (/^Validate/i.test(normalized)) return false;
+  if (/^Alias/i.test(normalized)) return false;
+  if (/^OutputType/i.test(normalized)) return false;
+  if (/^Allow/i.test(normalized)) return false;
+  return /^[A-Za-z0-9_.\[\]]+$/.test(normalized);
+}
+
+function parseParamDefinitions(block) {
+  if (!block) return [];
+  const lines = block.split(/\r?\n/);
+  const params = [];
+  let pendingType = '';
+  let collectedAttributes = [];
+
+  lines.forEach(rawLine => {
+    const line = rawLine.trim();
+    if (!line) return;
+    if (line.startsWith('#')) return;
+
+    const definitionMatch = line.match(
+      /^(?:\[[^\]]+\]\s*)*\$([A-Za-z0-9_:-]+)(?=\s|=|,|$)/
+    );
+
+    if (definitionMatch) {
+      const name = definitionMatch[1];
+      const equalsIndex = line.indexOf('=');
+      let rawDefault = '';
+      if (equalsIndex !== -1) {
+        rawDefault = line
+          .slice(equalsIndex + 1)
+          .replace(/,\s*$/, '')
+          .trim();
+      }
+      const typeMatch = line.match(/\[([^\]]+)\]\s*\$[A-Za-z0-9_:-]+/);
+      let type = '';
+      if (typeMatch) {
+        type = typeMatch[1].trim();
+      } else if (pendingType) {
+        type = pendingType;
+      }
+      const attributeText = collectedAttributes.join(' ');
+      const required = /Mandatory\s*=\s*\$true/i.test(attributeText);
+      const isSwitch =
+        /\[switch\]/i.test(line) ||
+        /\[switch\]/i.test(type) ||
+        /System\.Management\.Automation\.SwitchParameter/i.test(type);
+      const defaultValue = stripQuotes(rawDefault);
+      const defaultQuoteMatch = rawDefault.match(/^(["']).*\1$/);
+      const defaultQuote = defaultQuoteMatch ? defaultQuoteMatch[1] : '';
+
+      params.push({
+        name,
+        type,
+        required,
+        isSwitch,
+        defaultValue,
+        defaultRaw: rawDefault,
+        defaultQuote,
+      });
+      pendingType = '';
+      collectedAttributes = [];
+    } else {
+      const bracketMatch = line.match(/^\[([^\]]+)\]$/);
+      if (bracketMatch && isLikelyTypeAttribute(bracketMatch[1])) {
+        pendingType = bracketMatch[1].trim();
+      } else if (line.startsWith('[')) {
+        collectedAttributes.push(line);
+      }
+    }
+  });
+
+  return params;
+}
+
+function findPlaceholder(examples, paramName) {
+  if (!examples || !examples.length) {
+    return { placeholder: '', quote: '' };
+  }
+  const colonPattern = new RegExp(
+    `-${paramName}:("[^"]*"|'[^']*'|\\S+)`,
+    'i'
+  );
+  const spacePattern = new RegExp(
+    `-${paramName}\\s+("[^"]*"|'[^']*'|\\S+)`,
+    'i'
+  );
+  for (const example of examples) {
+    let match = example.match(colonPattern);
+    if (!match) {
+      match = example.match(spacePattern);
+    }
+    if (match) {
+      const raw = match[1].trim();
+      const quoteMatch = raw.match(/^(["'])([\s\S]*)\1$/);
+      if (quoteMatch) {
+        return { placeholder: quoteMatch[2], quote: quoteMatch[1] };
+      }
+      return { placeholder: raw, quote: '' };
+    }
+  }
+  return { placeholder: '', quote: '' };
 }
 
 function buildMetadata() {
@@ -63,16 +233,52 @@ function buildMetadata() {
     const start = match.index + match[0].length;
     const remainder = text.slice(start);
     const nextFunctionMatch = remainder.match(/\nfunction\s+[A-Za-z0-9-]+\s*\{/);
-    const section = nextFunctionMatch ? remainder.slice(0, nextFunctionMatch.index) : remainder;
+    const section = nextFunctionMatch
+      ? remainder.slice(0, nextFunctionMatch.index)
+      : remainder;
     const commentMatch = section.match(/<#[\s\S]*?#>/);
     const comment = commentMatch ? commentMatch[0] : '';
     const info = parseCommentBlock(comment);
+    const paramBlock = extractParamBlock(section);
+    const definitions = parseParamDefinitions(paramBlock);
+    const definitionMap = new Map();
+    definitions.forEach(def => {
+      definitionMap.set(def.name.toLowerCase(), def);
+    });
+
+    const combinedNames = new Set();
+    info.parameters.forEach(param => combinedNames.add(param.name));
+    definitions.forEach(def => combinedNames.add(def.name));
+
+    const parameters = [];
+    combinedNames.forEach(paramName => {
+      const def = definitionMap.get(paramName.toLowerCase());
+      const doc = info.parameters.find(
+        p => p.name.toLowerCase() === paramName.toLowerCase()
+      );
+      const exampleInfo = findPlaceholder(info.examples, paramName);
+      parameters.push({
+        name: doc ? doc.name : def ? def.name : paramName,
+        description: doc ? doc.description : '',
+        required: def ? def.required : false,
+        isSwitch: def ? def.isSwitch : false,
+        type: def ? def.type : '',
+        defaultValue: def ? def.defaultValue : '',
+        defaultRaw: def ? def.defaultRaw : '',
+        defaultQuote: def ? def.defaultQuote : '',
+        placeholder: exampleInfo.placeholder,
+        placeholderQuote: exampleInfo.quote,
+      });
+    });
+
+    parameters.sort((a, b) => a.name.localeCompare(b.name));
+
     metadata.push({
       name,
       synopsis: info.synopsis,
       description: info.description,
       link: info.link,
-      parameters: info.parameters,
+      parameters,
     });
   }
   metadata.sort((a, b) => a.name.localeCompare(b.name));

--- a/src/data/command-metadata.json
+++ b/src/data/command-metadata.json
@@ -7,19 +7,51 @@
     "parameters": [
       {
         "name": "ExtensionID",
-        "description": "The ID of the extension to add."
-      },
-      {
-        "name": "UpdateUrl",
-        "description": "The update URL of the extension. This is the URL where the extension will check for updates."
+        "description": "The ID of the extension to add.",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "extensionID",
+        "placeholderQuote": "\""
       },
       {
         "name": "InstallationMode",
-        "description": "The installation mode of the extension. Allowed values: blocked, allowed, removed, force_installed, normal_installed."
+        "description": "The installation mode of the extension. Allowed values: blocked, allowed, removed, force_installed, normal_installed.",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "force_installed",
+        "placeholderQuote": "\""
       },
       {
         "name": "MinimumVersionRequired",
-        "description": "The minimum version of the extension required for installation."
+        "description": "The minimum version of the extension required for installation.",
+        "required": false,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "UpdateUrl",
+        "description": "The update URL of the extension. This is the URL where the extension will check for updates.",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "https://edge.microsoft.com/extensionwebstorebase/v1/crx",
+        "placeholderQuote": "\""
       }
     ]
   },
@@ -30,12 +62,28 @@
     "link": "https://psappdeploytoolkit.com/docs/reference/functions/Add-ADTModuleCallback",
     "parameters": [
       {
-        "name": "Hookpoint",
-        "description": "Where you wish for the callback to be executed at. Valid hookpoints are: * OnInit (The callback is executed before the module is initialized) * OnStart (The callback is executed before the first deployment session is opened) * PreOpen (The callback is executed before a deployment session is opened) * PostOpen (The callback is executed after a deployment session is opened) * PreClose (The callback is executed before the deployment session is closed) * PostClose (The callback is executed after the deployment session is closed) * OnFinish (The callback is executed before the last deployment session is closed) * OnExit (The callback is executed after the last deployment session is closed) Each hook point supports multiple callbacks, each invoked in the order they're added. To see a list all the registered callbacks in order, use `Get-ADTModuleCallback`."
+        "name": "Callback",
+        "description": "The callback function to add to the nominated hooking point.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "(Get-Command",
+        "placeholderQuote": ""
       },
       {
-        "name": "Callback",
-        "description": "The callback function to add to the nominated hooking point."
+        "name": "Hookpoint",
+        "description": "Where you wish for the callback to be executed at. Valid hookpoints are: * OnInit (The callback is executed before the module is initialized) * OnStart (The callback is executed before the first deployment session is opened) * PreOpen (The callback is executed before a deployment session is opened) * PostOpen (The callback is executed after a deployment session is opened) * PreClose (The callback is executed before the deployment session is closed) * PostClose (The callback is executed after the deployment session is closed) * OnFinish (The callback is executed before the last deployment session is closed) * OnExit (The callback is executed after the last deployment session is closed) Each hook point supports multiple callbacks, each invoked in the order they're added. To see a list all the registered callbacks in order, use `Get-ADTModuleCallback`.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "PostOpen",
+        "placeholderQuote": ""
       }
     ]
   },
@@ -47,11 +95,27 @@
     "parameters": [
       {
         "name": "ProcessName",
-        "description": "Name of the process or processes separated by commas."
+        "description": "Name of the process or processes separated by commas.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "('winword','excel')",
+        "placeholderQuote": ""
       },
       {
         "name": "WindowLocation",
-        "description": "The location of the dialog on the screen."
+        "description": "The location of the dialog on the screen.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       }
     ]
   },
@@ -63,7 +127,15 @@
     "parameters": [
       {
         "name": "Hookpoint",
-        "description": "The callback hook point that you wish to clear. Valid hookpoints are: * OnInit (The callback is executed before the module is initialized) * OnStart (The callback is executed before the first deployment session is opened) * PreOpen (The callback is executed before a deployment session is opened) * PostOpen (The callback is executed after a deployment session is opened) * PreClose (The callback is executed before the deployment session is closed) * PostClose (The callback is executed after the deployment session is closed) * OnFinish (The callback is executed before the last deployment session is closed) * OnExit (The callback is executed after the last deployment session is closed) To see a list all the registered callbacks in order, use `Get-ADTModuleCallback`."
+        "description": "The callback hook point that you wish to clear. Valid hookpoints are: * OnInit (The callback is executed before the module is initialized) * OnStart (The callback is executed before the first deployment session is opened) * PreOpen (The callback is executed before a deployment session is opened) * PostOpen (The callback is executed after a deployment session is opened) * PreClose (The callback is executed before the deployment session is closed) * PostClose (The callback is executed after the deployment session is closed) * OnFinish (The callback is executed before the last deployment session is closed) * OnExit (The callback is executed after the last deployment session is closed) To see a list all the registered callbacks in order, use `Get-ADTModuleCallback`.",
+        "required": true,
+        "isSwitch": false,
+        "type": "PSADT.Module.CallbackType",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "PostOpen",
+        "placeholderQuote": ""
       }
     ]
   },
@@ -82,19 +154,51 @@
     "parameters": [
       {
         "name": "ExitCode",
-        "description": "The exit code to set for the session."
-      },
-      {
-        "name": "NoShellExit",
-        "description": "Doesn't exit PowerShell upon closing of the final session."
+        "description": "The exit code to set for the session.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "0",
+        "placeholderQuote": ""
       },
       {
         "name": "Force",
-        "description": "Forcibly exits PowerShell upon closing of the final session."
+        "description": "Forcibly exits PowerShell upon closing of the final session.",
+        "required": true,
+        "isSwitch": true,
+        "type": "System.Management.Automation.SwitchParameter",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "NoShellExit",
+        "description": "Doesn't exit PowerShell upon closing of the final session.",
+        "required": true,
+        "isSwitch": true,
+        "type": "System.Management.Automation.SwitchParameter",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "PassThru",
-        "description": "Returns the exit code of the session being closed."
+        "description": "Returns the exit code of the session being closed.",
+        "required": false,
+        "isSwitch": true,
+        "type": "System.Management.Automation.SwitchParameter",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       }
     ]
   },
@@ -106,7 +210,15 @@
     "parameters": [
       {
         "name": "Cmdlet",
-        "description": "The PSCmdlet object representing the cmdlet being completed."
+        "description": "The PSCmdlet object representing the cmdlet being completed.",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.Management.Automation.PSCmdlet",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "$PSCmdlet",
+        "placeholderQuote": ""
       }
     ]
   },
@@ -115,7 +227,20 @@
     "synopsis": "",
     "description": "",
     "link": "",
-    "parameters": []
+    "parameters": [
+      {
+        "name": "TargetNtAccount",
+        "description": "",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.Security.Principal.NTAccount",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      }
+    ]
   },
   {
     "name": "Convert-ADTRegistryPath",
@@ -125,15 +250,39 @@
     "parameters": [
       {
         "name": "Key",
-        "description": "Path to the registry key to convert (can be a registry hive or fully qualified path)"
-      },
-      {
-        "name": "Wow6432Node",
-        "description": "Specifies that the 32-bit registry view (Wow6432Node) should be used on a 64-bit system."
+        "description": "Path to the registry key to convert (can be a registry hive or fully qualified path)",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\TreeSize Free_is1",
+        "placeholderQuote": "'"
       },
       {
         "name": "SID",
-        "description": "The security identifier (SID) for a user. Specifying this parameter will convert a HKEY_CURRENT_USER registry key to the HKEY_USERS\\$SID format. Specify this parameter from the Invoke-ADTAllUsersRegistryAction function to read/edit HKCU registry settings for all users on the system."
+        "description": "The security identifier (SID) for a user. Specifying this parameter will convert a HKEY_CURRENT_USER registry key to the HKEY_USERS\\$SID format. Specify this parameter from the Invoke-ADTAllUsersRegistryAction function to read/edit HKCU registry settings for all users on the system.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "Wow6432Node",
+        "description": "Specifies that the 32-bit registry view (Wow6432Node) should be used on a 64-bit system.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       }
     ]
   },
@@ -142,7 +291,20 @@
     "synopsis": "",
     "description": "",
     "link": "",
-    "parameters": []
+    "parameters": [
+      {
+        "name": "TargetSid",
+        "description": "",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.Security.Principal.SecurityIdentifier",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      }
+    ]
   },
   {
     "name": "Convert-ADTValuesFromRemainingArguments",
@@ -152,7 +314,15 @@
     "parameters": [
       {
         "name": "RemainingArguments",
-        "description": "The collected values to enumerate and process into a dictionary."
+        "description": "The collected values to enumerate and process into a dictionary.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "$args",
+        "placeholderQuote": ""
       }
     ]
   },
@@ -163,12 +333,28 @@
     "link": "https://psappdeploytoolkit.com/docs/reference/functions/Convert-ADTValueType",
     "parameters": [
       {
-        "name": "Value",
-        "description": "The value to convert."
+        "name": "To",
+        "description": "What to cast the value to.",
+        "required": true,
+        "isSwitch": false,
+        "type": "PSADT.Utilities.ValueTypeConverter+ValueTypes",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "SByte",
+        "placeholderQuote": ""
       },
       {
-        "name": "To",
-        "description": "What to cast the value to."
+        "name": "Value",
+        "description": "The value to convert.",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.Int64",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "256",
+        "placeholderQuote": ""
       }
     ]
   },
@@ -180,27 +366,75 @@
     "parameters": [
       {
         "name": "AccountName",
-        "description": "The Windows NT Account name specified in <domain>\\<username> format. Use fully qualified account names (e.g., <domain>\\<username>) instead of isolated names (e.g, <username>) because they are unambiguous and provide better performance."
-      },
-      {
-        "name": "SID",
-        "description": "The Windows NT Account SID."
-      },
-      {
-        "name": "WellKnownSIDName",
-        "description": "Specify the Well Known SID name translate to the actual SID (e.g., LocalServiceSid). To get all well known SIDs available on system: [Enum]::GetNames([Security.Principal.WellKnownSidType])"
-      },
-      {
-        "name": "WellKnownToNTAccount",
-        "description": "Convert the Well Known SID to an NTAccount name."
-      },
-      {
-        "name": "LocalHost",
-        "description": "Avoids a costly domain check when only converting local accounts."
+        "description": "The Windows NT Account name specified in <domain>\\<username> format. Use fully qualified account names (e.g., <domain>\\<username>) instead of isolated names (e.g, <username>) because they are unambiguous and provide better performance.",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.Security.Principal.NTAccount",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "CONTOSO\\User1",
+        "placeholderQuote": "'"
       },
       {
         "name": "LdapUri",
-        "description": "Allows specification of the LDAP URI to use, either `LDAP://` or `LDAPS://`."
+        "description": "Allows specification of the LDAP URI to use, either `LDAP://` or `LDAPS://`.",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "LDAP://",
+        "defaultRaw": "'LDAP://'",
+        "defaultQuote": "'",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "LocalHost",
+        "description": "Avoids a costly domain check when only converting local accounts.",
+        "required": true,
+        "isSwitch": true,
+        "type": "System.Management.Automation.SwitchParameter",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "SID",
+        "description": "The Windows NT Account SID.",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.Security.Principal.SecurityIdentifier",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "S-1-5-21-1220945662-2111687655-725345543-14012660",
+        "placeholderQuote": "'"
+      },
+      {
+        "name": "WellKnownSIDName",
+        "description": "Specify the Well Known SID name translate to the actual SID (e.g., LocalServiceSid). To get all well known SIDs available on system: [Enum]::GetNames([Security.Principal.WellKnownSidType])",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.Security.Principal.WellKnownSidType",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "NetworkServiceSid",
+        "placeholderQuote": "'"
+      },
+      {
+        "name": "WellKnownToNTAccount",
+        "description": "Convert the Well Known SID to an NTAccount name.",
+        "required": false,
+        "isSwitch": true,
+        "type": "System.Management.Automation.SwitchParameter",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       }
     ]
   },
@@ -212,7 +446,15 @@
     "parameters": [
       {
         "name": "LiteralPath",
-        "description": "The path to the software cache folder."
+        "description": "The path to the software cache folder.",
+        "required": false,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "$((& $Script:CommandTable.'Get-ADTConfig').Toolkit.CachePath)\\$((& $Script:CommandTable.'Get-ADTSession').InstallName)",
+        "defaultRaw": "\"$((& $Script:CommandTable.'Get-ADTConfig').Toolkit.CachePath)\\$((& $Script:CommandTable.'Get-ADTSession').InstallName)\"",
+        "defaultQuote": "\"",
+        "placeholder": "$envWinDir\\Temp\\PSAppDeployToolkit",
+        "placeholderQuote": "\""
       }
     ]
   },
@@ -223,36 +465,100 @@
     "link": "https://psappdeploytoolkit.com/docs/reference/functions/Copy-ADTFile",
     "parameters": [
       {
-        "name": "Path",
-        "description": "Path of the file to copy. Multiple paths can be specified."
+        "name": "ContinueFileCopyOnError",
+        "description": "Continue copying files if an error is encountered. This will continue the deployment script and will warn about files that failed to be copied.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "Destination",
-        "description": "Destination Path of the file to copy."
-      },
-      {
-        "name": "Recurse",
-        "description": "Copy files in subdirectories."
-      },
-      {
-        "name": "Flatten",
-        "description": "Flattens the files into the root destination directory."
-      },
-      {
-        "name": "ContinueFileCopyOnError",
-        "description": "Continue copying files if an error is encountered. This will continue the deployment script and will warn about files that failed to be copied."
+        "description": "Destination Path of the file to copy.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "D:\\Destination\\file.txt",
+        "placeholderQuote": "'"
       },
       {
         "name": "FileCopyMode",
-        "description": "Select from 'Native' or 'Robocopy'. Default is configured in config.psd1. Note that Robocopy supports * in file names, but not folders, in source paths."
+        "description": "Select from 'Native' or 'Robocopy'. Default is configured in config.psd1. Note that Robocopy supports * in file names, but not folders, in source paths.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
-        "name": "RobocopyParams",
-        "description": "Override the default Robocopy parameters."
+        "name": "Flatten",
+        "description": "Flattens the files into the root destination directory.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "Path",
+        "description": "Path of the file to copy. Multiple paths can be specified.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "C:\\Path\\file.txt",
+        "placeholderQuote": "'"
+      },
+      {
+        "name": "Recurse",
+        "description": "Copy files in subdirectories.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "RobocopyAdditionalParams",
-        "description": "Append to the default Robocopy parameters."
+        "description": "Append to the default Robocopy parameters.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "RobocopyParams",
+        "description": "Override the default Robocopy parameters.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       }
     ]
   },
@@ -263,60 +569,172 @@
     "link": "https://psappdeploytoolkit.com/docs/reference/functions/Copy-ADTFileToUserProfiles",
     "parameters": [
       {
-        "name": "Path",
-        "description": "The path of the file or folder to copy."
-      },
-      {
-        "name": "Destination",
-        "description": "The path of the destination folder to append to the root of the user profile."
-      },
-      {
         "name": "BasePath",
-        "description": "The base path to append the destination folder to."
-      },
-      {
-        "name": "Recurse",
-        "description": "Copy files in subdirectories."
-      },
-      {
-        "name": "Flatten",
-        "description": "Flattens the files into the root destination directory."
+        "description": "The base path to append the destination folder to.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "Documents",
+        "placeholderQuote": "\""
       },
       {
         "name": "ContinueFileCopyOnError",
-        "description": "Continue copying files if an error is encountered. This will continue the deployment script and will warn about files that failed to be copied."
+        "description": "Continue copying files if an error is encountered. This will continue the deployment script and will warn about files that failed to be copied.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
-        "name": "FileCopyMode",
-        "description": "Select from 'Native' or 'Robocopy'. Default is configured in config.psd1. Note that Robocopy supports * in file names, but not folders, in source paths."
-      },
-      {
-        "name": "RobocopyParams",
-        "description": "Override the default Robocopy parameters."
-      },
-      {
-        "name": "RobocopyAdditionalParams",
-        "description": "Append to the default Robocopy parameters."
-      },
-      {
-        "name": "UserProfiles",
-        "description": "Specifies one or more UserProfile objects to copy files into."
-      },
-      {
-        "name": "ExcludeNTAccount",
-        "description": "Specify NT account names in Domain\\Username format to exclude from the list of user profiles."
-      },
-      {
-        "name": "IncludeSystemProfiles",
-        "description": "Include system profiles: SYSTEM, LOCAL SERVICE, NETWORK SERVICE."
-      },
-      {
-        "name": "IncludeServiceProfiles",
-        "description": "Include service profiles where NTAccount begins with NT SERVICE."
+        "name": "Destination",
+        "description": "The path of the destination folder to append to the root of the user profile.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "AppData\\Roaming\\MyApp",
+        "placeholderQuote": "\""
       },
       {
         "name": "ExcludeDefaultUser",
-        "description": "Exclude the Default User."
+        "description": "Exclude the Default User.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "ExcludeNTAccount",
+        "description": "Specify NT account names in Domain\\Username format to exclude from the list of user profiles.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "FileCopyMode",
+        "description": "Select from 'Native' or 'Robocopy'. Default is configured in config.psd1. Note that Robocopy supports * in file names, but not folders, in source paths.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "Flatten",
+        "description": "Flattens the files into the root destination directory.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "IncludeServiceProfiles",
+        "description": "Include service profiles where NTAccount begins with NT SERVICE.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "IncludeSystemProfiles",
+        "description": "Include system profiles: SYSTEM, LOCAL SERVICE, NETWORK SERVICE.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "Path",
+        "description": "The path of the file or folder to copy.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "$($adtSession.DirSupportFiles)\\config.txt",
+        "placeholderQuote": "\""
+      },
+      {
+        "name": "Recurse",
+        "description": "Copy files in subdirectories.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "RobocopyAdditionalParams",
+        "description": "Append to the default Robocopy parameters.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "RobocopyParams",
+        "description": "Override the default Robocopy parameters.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "UserProfiles",
+        "description": "Specifies one or more UserProfile objects to copy files into.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       }
     ]
   },
@@ -335,11 +753,27 @@
     "parameters": [
       {
         "name": "ImagePath",
-        "description": "The path to the WIM file."
+        "description": "The path to the WIM file.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "C:\\Path\\To\\File.wim",
+        "placeholderQuote": "'"
       },
       {
         "name": "Path",
-        "description": "The path to the WIM mount point."
+        "description": "The path to the WIM mount point.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "C:\\Mount\\WIM",
+        "placeholderQuote": "'"
       }
     ]
   },
@@ -355,7 +789,20 @@
     "synopsis": "",
     "description": "",
     "link": "",
-    "parameters": []
+    "parameters": [
+      {
+        "name": "Cmdlet",
+        "description": "",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.Management.Automation.PSCmdlet",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      }
+    ]
   },
   {
     "name": "Export-ADTEnvironmentTableToSessionState",
@@ -365,7 +812,15 @@
     "parameters": [
       {
         "name": "SessionState",
-        "description": "Defaults to $PSCmdlet.SessionState to get the caller's SessionState, so only required if you need to override this."
+        "description": "Defaults to $PSCmdlet.SessionState to get the caller's SessionState, so only required if you need to override this.",
+        "required": false,
+        "isSwitch": false,
+        "type": "System.Management.Automation.SessionState",
+        "defaultValue": "$PSCmdlet.SessionState",
+        "defaultRaw": "$PSCmdlet.SessionState",
+        "defaultQuote": "",
+        "placeholder": "$ExecutionContext.SessionState",
+        "placeholderQuote": ""
       }
     ]
   },
@@ -374,7 +829,20 @@
     "synopsis": "",
     "description": "",
     "link": "",
-    "parameters": []
+    "parameters": [
+      {
+        "name": "InputObject",
+        "description": "",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      }
+    ]
   },
   {
     "name": "Get-ADTApplication",
@@ -383,28 +851,76 @@
     "link": "https://psappdeploytoolkit.com/docs/reference/functions/Get-ADTApplication",
     "parameters": [
       {
-        "name": "Name",
-        "description": "The name of the application to retrieve information for. Performs a contains match on the application display name by default."
-      },
-      {
-        "name": "NameMatch",
-        "description": "Specifies the type of match to perform on the application name. Valid values are 'Contains', 'Exact', 'Wildcard', and 'Regex'. The default value is 'Contains'."
-      },
-      {
-        "name": "ProductCode",
-        "description": "The product code of the application to retrieve information for."
-      },
-      {
         "name": "ApplicationType",
-        "description": "Specifies the type of application to remove. Valid values are 'All', 'MSI', and 'EXE'. The default value is 'All'."
-      },
-      {
-        "name": "IncludeUpdatesAndHotfixes",
-        "description": "Include matches against updates and hotfixes in results."
+        "description": "Specifies the type of application to remove. Valid values are 'All', 'MSI', and 'EXE'. The default value is 'All'.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "MSI",
+        "placeholderQuote": "'"
       },
       {
         "name": "FilterScript",
-        "description": "A script used to filter the results as they're processed."
+        "description": "A script used to filter the results as they're processed.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "{",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "IncludeUpdatesAndHotfixes",
+        "description": "Include matches against updates and hotfixes in results.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "Name",
+        "description": "The name of the application to retrieve information for. Performs a contains match on the application display name by default.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "Acrobat",
+        "placeholderQuote": "'"
+      },
+      {
+        "name": "NameMatch",
+        "description": "Specifies the type of match to perform on the application name. Valid values are 'Contains', 'Exact', 'Wildcard', and 'Regex'. The default value is 'Contains'.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "Exact",
+        "placeholderQuote": "'"
+      },
+      {
+        "name": "ProductCode",
+        "description": "The product code of the application to retrieve information for.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "{AC76BA86-7AD7-1033-7B44-AC0F074E4100}",
+        "placeholderQuote": "'"
       }
     ]
   },
@@ -415,24 +931,64 @@
     "link": "https://psappdeploytoolkit.com/docs/reference/functions/Get-ADTBoundParametersAndDefaultValues",
     "parameters": [
       {
-        "name": "Invocation",
-        "description": "The script or function's InvocationInfo ($MyInvocation) to process."
-      },
-      {
-        "name": "ParameterSetName",
-        "description": "The ParameterSetName to use as a filter against the Invocation's parameters."
-      },
-      {
-        "name": "HelpMessage",
-        "description": "The HelpMessage field to use as a filter against the Invocation's parameters."
+        "name": "CommonParameters",
+        "description": "Specifies whether PowerShell advanced function common parameters should be included.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "Exclude",
-        "description": "One or more parameter names to exclude from the results."
+        "description": "One or more parameter names to exclude from the results.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
-        "name": "CommonParameters",
-        "description": "Specifies whether PowerShell advanced function common parameters should be included."
+        "name": "HelpMessage",
+        "description": "The HelpMessage field to use as a filter against the Invocation's parameters.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "Invocation",
+        "description": "The script or function's InvocationInfo ($MyInvocation) to process.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "$MyInvocation",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "ParameterSetName",
+        "description": "The ParameterSetName to use as a filter against the Invocation's parameters.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       }
     ]
   },
@@ -478,12 +1034,28 @@
     "link": "https://psappdeploytoolkit.com/docs/reference/functions/Get-ADTEnvironmentVariable",
     "parameters": [
       {
-        "name": "Variable",
-        "description": "The variable to get."
+        "name": "Target",
+        "description": "The target of the variable to get. This can be the machine, user, or process.",
+        "required": false,
+        "isSwitch": false,
+        "type": "System.EnvironmentVariableTarget",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "Machine",
+        "placeholderQuote": ""
       },
       {
-        "name": "Target",
-        "description": "The target of the variable to get. This can be the machine, user, or process."
+        "name": "Variable",
+        "description": "The variable to get.",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "Path",
+        "placeholderQuote": ""
       }
     ]
   },
@@ -494,16 +1066,40 @@
     "link": "https://psappdeploytoolkit.com",
     "parameters": [
       {
-        "name": "Path",
-        "description": "One or more expandable executable paths to retrieve info from."
+        "name": "InputObject",
+        "description": "A FileInfo object to retrieve executable info from. Available for pipelining.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "LiteralPath",
-        "description": "One or more literal executable paths to retrieve info from."
+        "description": "One or more literal executable paths to retrieve info from.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "C:\\Windows\\system32\\cmd.exe",
+        "placeholderQuote": ""
       },
       {
-        "name": "InputObject",
-        "description": "A FileInfo object to retrieve executable info from. Available for pipelining."
+        "name": "Path",
+        "description": "One or more expandable executable paths to retrieve info from.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       }
     ]
   },
@@ -515,11 +1111,27 @@
     "parameters": [
       {
         "name": "File",
-        "description": "The path of the file."
+        "description": "The path of the file.",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.IO.FileInfo",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "$env:ProgramFilesX86\\Adobe\\Reader 11.0\\Reader\\AcroRd32.exe",
+        "placeholderQuote": "\""
       },
       {
         "name": "ProductVersion",
-        "description": "Switch that makes the command return the file's ProductVersion instead of its FileVersion."
+        "description": "Switch that makes the command return the file's ProductVersion instead of its FileVersion.",
+        "required": false,
+        "isSwitch": true,
+        "type": "System.Management.Automation.SwitchParameter",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       }
     ]
   },
@@ -531,7 +1143,15 @@
     "parameters": [
       {
         "name": "Drive",
-        "description": "The drive to check free disk space on."
+        "description": "The drive to check free disk space on.",
+        "required": false,
+        "isSwitch": false,
+        "type": "System.IO.DriveInfo",
+        "defaultValue": "[System.IO.Path]::GetPathRoot([System.Environment]::SystemDirectory)",
+        "defaultRaw": "[System.IO.Path]::GetPathRoot([System.Environment]::SystemDirectory)",
+        "defaultQuote": "",
+        "placeholder": "C:",
+        "placeholderQuote": "'"
       }
     ]
   },
@@ -543,11 +1163,27 @@
     "parameters": [
       {
         "name": "FilePath",
-        "description": "Path to the INI file."
+        "description": "Path to the INI file.",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "$env:ProgramFilesX86\\IBM\\Notes\\notes.ini",
+        "placeholderQuote": "\""
       },
       {
         "name": "Section",
-        "description": "Section within the INI file."
+        "description": "Section within the INI file.",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "Notes",
+        "placeholderQuote": "'"
       }
     ]
   },
@@ -559,15 +1195,39 @@
     "parameters": [
       {
         "name": "FilePath",
-        "description": "Path to the INI file."
-      },
-      {
-        "name": "Section",
-        "description": "Section within the INI file."
+        "description": "Path to the INI file.",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "$env:ProgramFilesX86\\IBM\\Notes\\notes.ini",
+        "placeholderQuote": "\""
       },
       {
         "name": "Key",
-        "description": "Key within the section of the INI file."
+        "description": "Key within the section of the INI file.",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "KeyFileName",
+        "placeholderQuote": "'"
+      },
+      {
+        "name": "Section",
+        "description": "Section within the INI file.",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "Notes",
+        "placeholderQuote": "'"
       }
     ]
   },
@@ -586,7 +1246,15 @@
     "parameters": [
       {
         "name": "Hookpoint",
-        "description": "The hook point to return the callbacks for. Valid hookpoints are: * OnInit (The callback is executed before the module is initialized) * OnStart (The callback is executed before the first deployment session is opened) * PreOpen (The callback is executed before a deployment session is opened) * PostOpen (The callback is executed after a deployment session is opened) * PreClose (The callback is executed before the deployment session is closed) * PostClose (The callback is executed after the deployment session is closed) * OnFinish (The callback is executed before the last deployment session is closed) * OnExit (The callback is executed after the last deployment session is closed)"
+        "description": "The hook point to return the callbacks for. Valid hookpoints are: * OnInit (The callback is executed before the module is initialized) * OnStart (The callback is executed before the first deployment session is opened) * PreOpen (The callback is executed before a deployment session is opened) * PostOpen (The callback is executed after a deployment session is opened) * PreClose (The callback is executed before the deployment session is closed) * PostClose (The callback is executed after the deployment session is closed) * OnFinish (The callback is executed before the last deployment session is closed) * OnExit (The callback is executed after the last deployment session is closed)",
+        "required": true,
+        "isSwitch": false,
+        "type": "PSADT.Module.CallbackType",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "PostOpen",
+        "placeholderQuote": ""
       }
     ]
   },
@@ -598,7 +1266,15 @@
     "parameters": [
       {
         "name": "MsiExitCode",
-        "description": "MSI exit code."
+        "description": "MSI exit code.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "1618",
+        "placeholderQuote": ""
       }
     ]
   },
@@ -609,28 +1285,76 @@
     "link": "https://psappdeploytoolkit.com/docs/reference/functions/Get-ADTMsiTableProperty",
     "parameters": [
       {
-        "name": "LiteralPath",
-        "description": "The fully qualified path to an database file. Supports .msi and .msp files."
+        "name": "GetSummaryInformation",
+        "description": "Retrieves the Summary Information for the Windows Installer database. Summary Information property descriptions: https://msdn.microsoft.com/en-us/library/aa372049(v=vs.85).aspx",
+        "required": true,
+        "isSwitch": true,
+        "type": "System.Management.Automation.SwitchParameter",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
-        "name": "TransformPath",
-        "description": "The fully qualified path to a list of MST file(s) which should be applied to the MSI file."
+        "name": "LiteralPath",
+        "description": "The fully qualified path to an database file. Supports .msi and .msp files.",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "C:\\Package\\AppDeploy.msi",
+        "placeholderQuote": "'"
       },
       {
         "name": "Table",
-        "description": "The name of the the MSI table from which all of the properties must be retrieved."
+        "description": "The name of the the MSI table from which all of the properties must be retrieved.",
+        "required": false,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "[System.Management.Automation.Language.NullString]::Value",
+        "defaultRaw": "[System.Management.Automation.Language.NullString]::Value",
+        "defaultQuote": "",
+        "placeholder": "Property",
+        "placeholderQuote": "'"
       },
       {
         "name": "TablePropertyNameColumnNum",
-        "description": "Specify the table column number which contains the name of the properties."
+        "description": "Specify the table column number which contains the name of the properties.",
+        "required": false,
+        "isSwitch": false,
+        "type": "System.Int32",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "TablePropertyValueColumnNum",
-        "description": "Specify the table column number which contains the value of the properties."
+        "description": "Specify the table column number which contains the value of the properties.",
+        "required": false,
+        "isSwitch": false,
+        "type": "System.Int32",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
-        "name": "GetSummaryInformation",
-        "description": "Retrieves the Summary Information for the Windows Installer database. Summary Information property descriptions: https://msdn.microsoft.com/en-us/library/aa372049(v=vs.85).aspx"
+        "name": "TransformPath",
+        "description": "The fully qualified path to a list of MST file(s) which should be applied to the MSI file.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "C:\\Package\\AppDeploy.mst",
+        "placeholderQuote": "'"
       }
     ]
   },
@@ -641,16 +1365,40 @@
     "link": "https://psappdeploytoolkit.com/docs/reference/functions/Get-ADTObjectProperty",
     "parameters": [
       {
+        "name": "ArgumentList",
+        "description": "Argument to pass to the property being retrieved.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "@(1)",
+        "placeholderQuote": ""
+      },
+      {
         "name": "InputObject",
-        "description": "Specifies an object which has properties that can be retrieved."
+        "description": "Specifies an object which has properties that can be retrieved.",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.Object",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "$Record",
+        "placeholderQuote": ""
       },
       {
         "name": "PropertyName",
-        "description": "Specifies the name of a property to retrieve."
-      },
-      {
-        "name": "ArgumentList",
-        "description": "Argument to pass to the property being retrieved."
+        "description": "Specifies the name of a property to retrieve.",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "StringData",
+        "placeholderQuote": "'"
       }
     ]
   },
@@ -668,20 +1416,52 @@
     "link": "https://psappdeploytoolkit.com/docs/reference/functions/Get-ADTPEFileArchitecture",
     "parameters": [
       {
-        "name": "Path",
-        "description": "One or more expandable executable paths to retrieve info from."
+        "name": "InputObject",
+        "description": "A FileInfo object to retrieve executable info from. Available for pipelining.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "LiteralPath",
-        "description": "One or more literal executable paths to retrieve info from."
-      },
-      {
-        "name": "InputObject",
-        "description": "A FileInfo object to retrieve executable info from. Available for pipelining."
+        "description": "One or more literal executable paths to retrieve info from.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "PassThru",
-        "description": "Get the file object, attach a property indicating the file binary type, and write to pipeline."
+        "description": "Get the file object, attach a property indicating the file binary type, and write to pipeline.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "Path",
+        "description": "One or more expandable executable paths to retrieve info from.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       }
     ]
   },
@@ -713,32 +1493,88 @@
     "link": "https://psappdeploytoolkit.com/docs/reference/functions/Get-ADTRegistryKey",
     "parameters": [
       {
-        "name": "Path",
-        "description": "Path of the registry key, wildcards permitted."
+        "name": "DoNotExpandEnvironmentNames",
+        "description": "Return unexpanded REG_EXPAND_SZ values.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "LiteralPath",
-        "description": "Literal path of the registry key."
+        "description": "Literal path of the registry key.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "Name",
-        "description": "Value name to retrieve (optional)."
+        "description": "Value name to retrieve (optional).",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "Version",
+        "placeholderQuote": "'"
       },
       {
-        "name": "Wow6432Node",
-        "description": "Specify this switch to read the 32-bit registry (Wow6432Node) on 64-bit systems."
-      },
-      {
-        "name": "SID",
-        "description": "The security identifier (SID) for a user. Specifying this parameter will convert a HKEY_CURRENT_USER registry key to the HKEY_USERS\\$SID format. Specify this parameter from the Invoke-ADTAllUsersRegistryAction function to read/edit HKCU registry settings for all users on the system."
+        "name": "Path",
+        "description": "Path of the registry key, wildcards permitted.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "ReturnEmptyKeyIfExists",
-        "description": "Return the registry key if it exists but it has no property/value pairs underneath it."
+        "description": "Return the registry key if it exists but it has no property/value pairs underneath it.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
-        "name": "DoNotExpandEnvironmentNames",
-        "description": "Return unexpanded REG_EXPAND_SZ values."
+        "name": "SID",
+        "description": "The security identifier (SID) for a user. Specifying this parameter will convert a HKEY_CURRENT_USER registry key to the HKEY_USERS\\$SID format. Specify this parameter from the Invoke-ADTAllUsersRegistryAction function to read/edit HKCU registry settings for all users on the system.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "Wow6432Node",
+        "description": "Specify this switch to read the 32-bit registry (Wow6432Node) on 64-bit systems.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       }
     ]
   },
@@ -750,7 +1586,15 @@
     "parameters": [
       {
         "name": "ProcessObjects",
-        "description": "One or more process objects to search for."
+        "description": "One or more process objects to search for.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "$processObjects",
+        "placeholderQuote": ""
       }
     ]
   },
@@ -762,7 +1606,15 @@
     "parameters": [
       {
         "name": "Service",
-        "description": "Specify the service object to retrieve the startup mode for."
+        "description": "Specify the service object to retrieve the startup mode for.",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.ServiceProcess.ServiceController",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "(Get-Service",
+        "placeholderQuote": ""
       }
     ]
   },
@@ -781,7 +1633,15 @@
     "parameters": [
       {
         "name": "LiteralPath",
-        "description": "Path to the shortcut to get information from."
+        "description": "Path to the shortcut to get information from.",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "$envProgramData\\Microsoft\\Windows\\Start Menu\\My Shortcut.lnk",
+        "placeholderQuote": "\""
       }
     ]
   },
@@ -800,7 +1660,15 @@
     "parameters": [
       {
         "name": "DateTime",
-        "description": "Specify the DateTime in the current culture."
+        "description": "Specify the DateTime in the current culture.",
+        "required": false,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "[System.DateTime]::Now.ToString([System.Globalization.DateTimeFormatInfo]::CurrentInfo.UniversalSortableDateTimePattern).TrimEnd('Z')",
+        "defaultRaw": "[System.DateTime]::Now.ToString([System.Globalization.DateTimeFormatInfo]::CurrentInfo.UniversalSortableDateTimePattern).TrimEnd('Z')",
+        "defaultQuote": "",
+        "placeholder": "25/08/2013",
+        "placeholderQuote": "'"
       }
     ]
   },
@@ -818,32 +1686,88 @@
     "link": "https://psappdeploytoolkit.com/docs/reference/functions/Get-ADTUserProfiles",
     "parameters": [
       {
-        "name": "FilterScript",
-        "description": "Allows filtration of the returned result by any property in a UserProfile object."
+        "name": "ExcludeDefaultUser",
+        "description": "Exclude the Default User.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "ExcludeNTAccount",
-        "description": "Specify NT account names in DOMAIN\\username format to exclude from the list of user profiles."
+        "description": "Specify NT account names in DOMAIN\\username format to exclude from the list of user profiles.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "CONTOSO\\Robot,CONTOSO\\ntadmin",
+        "placeholderQuote": ""
       },
       {
-        "name": "IncludeSystemProfiles",
-        "description": "Include system profiles: SYSTEM, LOCAL SERVICE, NETWORK SERVICE."
-      },
-      {
-        "name": "IncludeServiceProfiles",
-        "description": "Include service (NT SERVICE) profiles."
+        "name": "FilterScript",
+        "description": "Allows filtration of the returned result by any property in a UserProfile object.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "IncludeIISAppPoolProfiles",
-        "description": "Include IIS AppPool profiles. Excluded by default as they don't parse well."
+        "description": "Include IIS AppPool profiles. Excluded by default as they don't parse well.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
-        "name": "ExcludeDefaultUser",
-        "description": "Exclude the Default User."
+        "name": "IncludeServiceProfiles",
+        "description": "Include service (NT SERVICE) profiles.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "IncludeSystemProfiles",
+        "description": "Include system profiles: SYSTEM, LOCAL SERVICE, NETWORK SERVICE.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "LoadProfilePaths",
-        "description": "Load additional profile paths for each user profile."
+        "description": "Load additional profile paths for each user profile.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       }
     ]
   },
@@ -854,16 +1778,40 @@
     "link": "https://psappdeploytoolkit.com/docs/reference/functions/Get-ADTWindowTitle",
     "parameters": [
       {
-        "name": "WindowTitle",
-        "description": "One or more titles of the application window to search for using regex matching."
+        "name": "ParentProcess",
+        "description": "One or more process names of the application window to search for.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "WindowHandle",
-        "description": "One or more window handles of the application window to search for."
+        "description": "One or more window handles of the application window to search for.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
-        "name": "ParentProcess",
-        "description": "One or more process names of the application window to search for."
+        "name": "WindowTitle",
+        "description": "One or more titles of the application window to search for using regex matching.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "Microsoft Word",
+        "placeholderQuote": "'"
       }
     ]
   },
@@ -875,11 +1823,27 @@
     "parameters": [
       {
         "name": "Cmdlet",
-        "description": "The cmdlet that is being initialized."
+        "description": "The cmdlet that is being initialized.",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.Management.Automation.PSCmdlet",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "$PSCmdlet",
+        "placeholderQuote": ""
       },
       {
         "name": "SessionState",
-        "description": "The session state of the cmdlet."
+        "description": "The session state of the cmdlet.",
+        "required": false,
+        "isSwitch": false,
+        "type": "System.Management.Automation.SessionState",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       }
     ]
   },
@@ -890,12 +1854,28 @@
     "link": "https://psappdeploytoolkit.com/docs/reference/functions/Initialize-ADTModule",
     "parameters": [
       {
-        "name": "ScriptDirectory",
-        "description": "An override directory to use for config and string loading."
+        "name": "AdditionalEnvironmentVariables",
+        "description": "A dictionary of key/value pairs to inject into the generated environment table.",
+        "required": false,
+        "isSwitch": false,
+        "type": "System.Collections.IDictionary",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
-        "name": "AdditionalEnvironmentVariables",
-        "description": "A dictionary of key/value pairs to inject into the generated environment table."
+        "name": "ScriptDirectory",
+        "description": "An override directory to use for config and string loading.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       }
     ]
   },
@@ -907,7 +1887,15 @@
     "parameters": [
       {
         "name": "Directory",
-        "description": "Directory containing the updates."
+        "description": "Directory containing the updates.",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "$($adtSession.DirFiles)\\MSUpdates",
+        "placeholderQuote": "\""
       }
     ]
   },
@@ -919,11 +1907,27 @@
     "parameters": [
       {
         "name": "SoftwareUpdatesScanWaitInSeconds",
-        "description": "The amount of time to wait in seconds for the software updates scan to complete."
+        "description": "The amount of time to wait in seconds for the software updates scan to complete.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "WaitForPendingUpdatesTimeout",
-        "description": "The amount of time to wait for missing and pending updates to install before exiting the function."
+        "description": "The amount of time to wait for missing and pending updates to install before exiting the function.",
+        "required": false,
+        "isSwitch": false,
+        "type": "System.TimeSpan",
+        "defaultValue": "[System.TimeSpan]::FromMinutes(45)",
+        "defaultRaw": "[System.TimeSpan]::FromMinutes(45)",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       }
     ]
   },
@@ -935,15 +1939,39 @@
     "parameters": [
       {
         "name": "ScriptBlock",
-        "description": "Script block which contains HKCU registry actions to be run for all users on the system."
-      },
-      {
-        "name": "UserProfiles",
-        "description": "Specify the user profiles to modify HKCU registry settings for. Default is all user profiles except for system profiles."
+        "description": "Script block which contains HKCU registry actions to be run for all users on the system.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "{",
+        "placeholderQuote": ""
       },
       {
         "name": "SkipUnloadedProfiles",
-        "description": "Specifies that unloaded registry hives should be skipped and not be loaded by the function."
+        "description": "Specifies that unloaded registry hives should be skipped and not be loaded by the function.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "UserProfiles",
+        "description": "Specify the user profiles to modify HKCU registry settings for. Default is all user profiles except for system profiles.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "(Get-ADTUserProfiles",
+        "placeholderQuote": ""
       }
     ]
   },
@@ -955,27 +1983,75 @@
     "parameters": [
       {
         "name": "Command",
-        "description": "The name of the command to invoke."
-      },
-      {
-        "name": "Retries",
-        "description": "How many retries to perform before throwing."
-      },
-      {
-        "name": "SleepDuration",
-        "description": "How long to sleep between retries."
+        "description": "The name of the command to invoke.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "Invoke-WebRequest",
+        "placeholderQuote": ""
       },
       {
         "name": "MaximumElapsedTime",
-        "description": "The maximum elapsed time allowed to passed while attempting retries. If the maximum elapsted time has passed and there are still attempts remaining they will be disgarded. If this parameter is supplied and the `-Retries` parameter isn't, this command will continue to retry the provided command until the time limit runs out."
-      },
-      {
-        "name": "SleepSeconds",
-        "description": "This parameter is obsolete and will be removed in PSAppDeployToolkit 4.2.0. Please use `-SleepDuration` instead."
+        "description": "The maximum elapsed time allowed to passed while attempting retries. If the maximum elapsted time has passed and there are still attempts remaining they will be disgarded. If this parameter is supplied and the `-Retries` parameter isn't, this command will continue to retry the provided command until the time limit runs out.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "(New-TimeSpan",
+        "placeholderQuote": ""
       },
       {
         "name": "Parameters",
-        "description": "A 'ValueFromRemainingArguments' parameter to collect the parameters as would be passed to the provided Command. While values can be directly provided to this parameter, it's not designed to be explicitly called."
+        "description": "A 'ValueFromRemainingArguments' parameter to collect the parameters as would be passed to the provided Command. While values can be directly provided to this parameter, it's not designed to be explicitly called.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "Retries",
+        "description": "How many retries to perform before throwing.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "5",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "SleepDuration",
+        "description": "How long to sleep between retries.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "(New-TimeSpan",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "SleepSeconds",
+        "description": "This parameter is obsolete and will be removed in PSAppDeployToolkit 4.2.0. Please use `-SleepDuration` instead.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       }
     ]
   },
@@ -993,36 +2069,100 @@
     "link": "https://psappdeploytoolkit.com/docs/reference/functions/Invoke-ADTFunctionErrorHandler",
     "parameters": [
       {
-        "name": "Cmdlet",
-        "description": "The cmdlet that is calling this function."
-      },
-      {
-        "name": "SessionState",
-        "description": "The session state of the calling cmdlet."
-      },
-      {
-        "name": "ErrorRecord",
-        "description": "The error record to handle."
-      },
-      {
-        "name": "LogMessage",
-        "description": "The error message to write to the active ADTSession's log file."
-      },
-      {
-        "name": "ResolveErrorProperties",
-        "description": "If specified, the specific ErrorRecord properties to print during resolution."
-      },
-      {
         "name": "AdditionalResolveErrorProperties",
-        "description": "If specified, a list of additional ErrorRecord properties to print during resolution."
+        "description": "If specified, a list of additional ErrorRecord properties to print during resolution.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "Cmdlet",
+        "description": "The cmdlet that is calling this function.",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.Management.Automation.PSCmdlet",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "$PSCmdlet",
+        "placeholderQuote": ""
       },
       {
         "name": "DisableErrorResolving",
-        "description": "If specified, the function will not append the resolved error record to the log message."
+        "description": "If specified, the function will not append the resolved error record to the log message.",
+        "required": true,
+        "isSwitch": true,
+        "type": "System.Management.Automation.SwitchParameter",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "ErrorRecord",
+        "description": "The error record to handle.",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.Management.Automation.ErrorRecord",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "$_",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "LogMessage",
+        "description": "The error message to write to the active ADTSession's log file.",
+        "required": false,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "[System.Management.Automation.Language.NullString]::Value",
+        "defaultRaw": "[System.Management.Automation.Language.NullString]::Value",
+        "defaultQuote": "",
+        "placeholder": "An error occurred",
+        "placeholderQuote": "\""
+      },
+      {
+        "name": "ResolveErrorProperties",
+        "description": "If specified, the specific ErrorRecord properties to print during resolution.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "SessionState",
+        "description": "The session state of the calling cmdlet.",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.Management.Automation.SessionState",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "$ExecutionContext.SessionState",
+        "placeholderQuote": ""
       },
       {
         "name": "Silent",
-        "description": "If specified, doesn't write anything to the log and just handles the ErrorRecord itself."
+        "description": "If specified, doesn't write anything to the log and just handles the ErrorRecord itself.",
+        "required": true,
+        "isSwitch": true,
+        "type": "System.Management.Automation.SwitchParameter",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       }
     ]
   },
@@ -1033,20 +2173,52 @@
     "link": "https://psappdeploytoolkit.com/docs/reference/functions/Invoke-ADTObjectMethod",
     "parameters": [
       {
+        "name": "ArgumentList",
+        "description": "Argument to pass to the method being executed. Allows execution of method without specifying named parameters.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
         "name": "InputObject",
-        "description": "Specifies an object which has methods that can be invoked."
+        "description": "Specifies an object which has methods that can be invoked.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "MethodName",
-        "description": "Specifies the name of a method to invoke."
-      },
-      {
-        "name": "ArgumentList",
-        "description": "Argument to pass to the method being executed. Allows execution of method without specifying named parameters."
+        "description": "Specifies the name of a method to invoke.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "Parameter",
-        "description": "Argument to pass to the method being executed. Allows execution of method by using named parameters."
+        "description": "Argument to pass to the method being executed. Allows execution of method by using named parameters.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       }
     ]
   },
@@ -1057,12 +2229,28 @@
     "link": "https://psappdeploytoolkit.com/docs/reference/functions/Invoke-ADTRegSvr32",
     "parameters": [
       {
-        "name": "FilePath",
-        "description": "Path to the DLL file."
+        "name": "Action",
+        "description": "Specify whether to register or unregister the DLL.",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "Register",
+        "placeholderQuote": "'"
       },
       {
-        "name": "Action",
-        "description": "Specify whether to register or unregister the DLL."
+        "name": "FilePath",
+        "description": "Path to the DLL file.",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "C:\\Test\\DcTLSFileToDMSComp.dll",
+        "placeholderQuote": "\""
       }
     ]
   },
@@ -1074,7 +2262,15 @@
     "parameters": [
       {
         "name": "ScheduleId",
-        "description": "Name of the Schedule Id to trigger."
+        "description": "Name of the Schedule Id to trigger.",
+        "required": true,
+        "isSwitch": false,
+        "type": "PSADT.ConfigMgr.TriggerScheduleId",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "SoftwareUpdatesScan",
+        "placeholderQuote": "'"
       }
     ]
   },
@@ -1085,28 +2281,76 @@
     "link": "https://psappdeploytoolkit.com/docs/reference/functions/Mount-ADTWimFile",
     "parameters": [
       {
-        "name": "ImagePath",
-        "description": "Path to the WIM file to be mounted."
+        "name": "Force",
+        "description": "Forces the removal of the existing directory if it is not empty.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
-        "name": "Path",
-        "description": "Directory where the WIM file will be mounted. The directory either must not exist, or must be empty and not have a pre-existing WIM mounted."
+        "name": "ImagePath",
+        "description": "Path to the WIM file to be mounted.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "C:\\Images\\install.wim",
+        "placeholderQuote": "'"
       },
       {
         "name": "Index",
-        "description": "Index of the image within the WIM file to be mounted."
+        "description": "Index of the image within the WIM file to be mounted.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "1",
+        "placeholderQuote": ""
       },
       {
         "name": "Name",
-        "description": "Name of the image within the WIM file to be mounted."
-      },
-      {
-        "name": "Force",
-        "description": "Forces the removal of the existing directory if it is not empty."
+        "description": "Name of the image within the WIM file to be mounted.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "Windows 10 Pro",
+        "placeholderQuote": "'"
       },
       {
         "name": "PassThru",
-        "description": "If specified, the function will return the results from `Mount-WindowsImage`."
+        "description": "If specified, the function will return the results from `Mount-WindowsImage`.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "Path",
+        "description": "Directory where the WIM file will be mounted. The directory either must not exist, or must be empty and not have a pre-existing WIM mounted.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "C:\\Mount",
+        "placeholderQuote": "'"
       }
     ]
   },
@@ -1117,40 +2361,112 @@
     "link": "https://psappdeploytoolkit.com/docs/reference/functions/New-ADTErrorRecord",
     "parameters": [
       {
-        "name": "Exception",
-        "description": "The exception object that caused the error."
+        "name": "Activity",
+        "description": "The activity that was being performed when the error occurred.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "Category",
-        "description": "The category of the error."
+        "description": "The category of the error.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "ErrorId",
-        "description": "The identifier for the error. Default is 'NotSpecified'."
+        "description": "The identifier for the error. Default is 'NotSpecified'.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
-        "name": "TargetObject",
-        "description": "The target object that the error is related to."
-      },
-      {
-        "name": "TargetName",
-        "description": "The name of the target that the error is related to."
-      },
-      {
-        "name": "TargetType",
-        "description": "The type of the target that the error is related to."
-      },
-      {
-        "name": "Activity",
-        "description": "The activity that was being performed when the error occurred."
+        "name": "Exception",
+        "description": "The exception object that caused the error.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "Reason",
-        "description": "The reason for the error."
+        "description": "The reason for the error.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "RecommendedAction",
-        "description": "The recommended action to resolve the error."
+        "description": "The recommended action to resolve the error.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "TargetName",
+        "description": "The name of the target that the error is related to.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "TargetObject",
+        "description": "The target object that the error is related to.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "TargetType",
+        "description": "The type of the target that the error is related to.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       }
     ]
   },
@@ -1162,7 +2478,15 @@
     "parameters": [
       {
         "name": "LiteralPath",
-        "description": "Path to the new folder to create."
+        "description": "Path to the new folder to create.",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "$env:WinDir\\System32",
+        "placeholderQuote": "\""
       }
     ]
   },
@@ -1173,20 +2497,52 @@
     "link": "https://psappdeploytoolkit.com/docs/reference/functions/New-ADTMsiTransform",
     "parameters": [
       {
-        "name": "MsiPath",
-        "description": "Specify the path to an MSI file."
+        "name": "ApplyTransformPath",
+        "description": "Specify the path to a transform which should be applied to the MSI database before any new properties are created or modified.",
+        "required": false,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "[System.Management.Automation.Language.NullString]::Value",
+        "defaultRaw": "[System.Management.Automation.Language.NullString]::Value",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
-        "name": "ApplyTransformPath",
-        "description": "Specify the path to a transform which should be applied to the MSI database before any new properties are created or modified."
+        "name": "MsiPath",
+        "description": "Specify the path to an MSI file.",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "C:\\Temp\\PSADTInstall.msi",
+        "placeholderQuote": "'"
       },
       {
         "name": "NewTransformPath",
-        "description": "Specify the path where the new transform file with the desired properties will be created. If a transform file of the same name already exists, it will be deleted before a new one is created."
+        "description": "Specify the path where the new transform file with the desired properties will be created. If a transform file of the same name already exists, it will be deleted before a new one is created.",
+        "required": false,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "[System.Management.Automation.Language.NullString]::Value",
+        "defaultRaw": "[System.Management.Automation.Language.NullString]::Value",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "TransformProperties",
-        "description": "Hashtable which contains calls to `Set-ADTMsiProperty` for configuring the desired properties which should be included in the new transform file. Example hashtable: `@{ ALLUSERS = 1 }`"
+        "description": "Hashtable which contains calls to `Set-ADTMsiProperty` for configuring the desired properties which should be included in the new transform file. Example hashtable: `@{ ALLUSERS = 1 }`",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.Collections.Hashtable",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "@{",
+        "placeholderQuote": ""
       }
     ]
   },
@@ -1197,44 +2553,124 @@
     "link": "https://psappdeploytoolkit.com/docs/reference/functions/New-ADTShortcut",
     "parameters": [
       {
-        "name": "LiteralPath",
-        "description": "Path to save the shortcut."
-      },
-      {
-        "name": "TargetPath",
-        "description": "Target path or URL that the shortcut launches."
-      },
-      {
         "name": "Arguments",
-        "description": "Arguments to be passed to the target path."
-      },
-      {
-        "name": "IconLocation",
-        "description": "Location of the icon used for the shortcut."
-      },
-      {
-        "name": "IconIndex",
-        "description": "The index of the icon. Executables, DLLs, ICO files with multiple icons need the icon index to be specified. This parameter is an Integer. The first index is 0."
+        "description": "Arguments to be passed to the target path.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "Description",
-        "description": "Description of the shortcut."
-      },
-      {
-        "name": "WorkingDirectory",
-        "description": "Working Directory to be used for the target path."
-      },
-      {
-        "name": "WindowStyle",
-        "description": "Windows style of the application. Options: Normal, Maximized, Minimized."
-      },
-      {
-        "name": "RunAsAdmin",
-        "description": "Set shortcut to run program as administrator. This option will prompt user to elevate when executing shortcut."
+        "description": "Description of the shortcut.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "Notepad",
+        "placeholderQuote": "'"
       },
       {
         "name": "Hotkey",
-        "description": "Create a Hotkey to launch the shortcut, e.g. \"CTRL+SHIFT+F\"."
+        "description": "Create a Hotkey to launch the shortcut, e.g. \"CTRL+SHIFT+F\".",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "IconIndex",
+        "description": "The index of the icon. Executables, DLLs, ICO files with multiple icons need the icon index to be specified. This parameter is an Integer. The first index is 0.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "IconLocation",
+        "description": "Location of the icon used for the shortcut.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "$envWinDir\\notepad.exe",
+        "placeholderQuote": "\""
+      },
+      {
+        "name": "LiteralPath",
+        "description": "Path to save the shortcut.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "$envCommonStartMenuPrograms\\My Shortcut.lnk",
+        "placeholderQuote": "\""
+      },
+      {
+        "name": "RunAsAdmin",
+        "description": "Set shortcut to run program as administrator. This option will prompt user to elevate when executing shortcut.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "TargetPath",
+        "description": "Target path or URL that the shortcut launches.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "$envWinDir\\notepad.exe",
+        "placeholderQuote": "\""
+      },
+      {
+        "name": "WindowStyle",
+        "description": "Windows style of the application. Options: Normal, Maximized, Minimized.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "WorkingDirectory",
+        "description": "Working Directory to be used for the target path.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "%HOMEDRIVE%\\%HOMEPATH%",
+        "placeholderQuote": "'"
       }
     ]
   },
@@ -1246,27 +2682,75 @@
     "parameters": [
       {
         "name": "Destination",
-        "description": "Path where the new folder should be created. Default is the current working directory."
-      },
-      {
-        "name": "Name",
-        "description": "Name of the newly created folder. Default is PSAppDeployToolkit_Version."
-      },
-      {
-        "name": "Version",
-        "description": "Defaults to 4 for the standard v4 template. Use 3 for the v3 compatibility mode template."
-      },
-      {
-        "name": "Show",
-        "description": "Opens the newly created folder in Windows Explorer."
+        "description": "Path where the new folder should be created. Default is the current working directory.",
+        "required": false,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "$ExecutionContext.SessionState.Path.CurrentLocation.Path",
+        "defaultRaw": "$ExecutionContext.SessionState.Path.CurrentLocation.Path",
+        "defaultQuote": "",
+        "placeholder": "C:\\Temp",
+        "placeholderQuote": "'"
       },
       {
         "name": "Force",
-        "description": "If the destination folder already exists, this switch will force the creation of the new folder."
+        "description": "If the destination folder already exists, this switch will force the creation of the new folder.",
+        "required": false,
+        "isSwitch": true,
+        "type": "System.Management.Automation.SwitchParameter",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "Name",
+        "description": "Name of the newly created folder. Default is PSAppDeployToolkit_Version.",
+        "required": false,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "$($MyInvocation.MyCommand.Module.Name)_$($MyInvocation.MyCommand.Module.Version)",
+        "defaultRaw": "\"$($MyInvocation.MyCommand.Module.Name)_$($MyInvocation.MyCommand.Module.Version)\"",
+        "defaultQuote": "\"",
+        "placeholder": "PSAppDeployToolkitv4",
+        "placeholderQuote": "'"
       },
       {
         "name": "PassThru",
-        "description": "Returns the newly created folder object."
+        "description": "Returns the newly created folder object.",
+        "required": false,
+        "isSwitch": true,
+        "type": "System.Management.Automation.SwitchParameter",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "Show",
+        "description": "Opens the newly created folder in Windows Explorer.",
+        "required": false,
+        "isSwitch": true,
+        "type": "System.Management.Automation.SwitchParameter",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "Version",
+        "description": "Defaults to 4 for the standard v4 template. Use 3 for the v3 compatibility mode template.",
+        "required": false,
+        "isSwitch": false,
+        "type": "System.Int32",
+        "defaultValue": "4",
+        "defaultRaw": "4",
+        "defaultQuote": "",
+        "placeholder": "3",
+        "placeholderQuote": ""
       }
     ]
   },
@@ -1277,20 +2761,52 @@
     "link": "https://psappdeploytoolkit.com/docs/reference/functions/New-ADTValidateScriptErrorRecord",
     "parameters": [
       {
-        "name": "ParameterName",
-        "description": "The name of the parameter that caused the validation error."
-      },
-      {
-        "name": "ProvidedValue",
-        "description": "The value provided for the parameter that caused the validation error."
-      },
-      {
         "name": "ExceptionMessage",
-        "description": "The message describing the validation error."
+        "description": "The message describing the validation error.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "InnerException",
-        "description": "An optional inner exception that provides more details about the validation error."
+        "description": "An optional inner exception that provides more details about the validation error.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "ParameterName",
+        "description": "The name of the parameter that caused the validation error.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "ProvidedValue",
+        "description": "The value provided for the parameter that caused the validation error.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       }
     ]
   },
@@ -1301,32 +2817,88 @@
     "link": "https://psappdeploytoolkit.com/docs/reference/functions/New-ADTZipFile",
     "parameters": [
       {
-        "name": "Path",
-        "description": "One or more paths to compress. Supports wildcards."
-      },
-      {
-        "name": "LiteralPath",
-        "description": "One or more literal paths to compress."
+        "name": "CompressionLevel",
+        "description": "The level of compression to apply to the zip file.",
+        "required": false,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "[System.Management.Automation.Language.NullString]::Value",
+        "defaultRaw": "[System.Management.Automation.Language.NullString]::Value",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "DestinationPath",
-        "description": "The file path for where the zip file should be created."
-      },
-      {
-        "name": "CompressionLevel",
-        "description": "The level of compression to apply to the zip file."
-      },
-      {
-        "name": "Update",
-        "description": "Specifies whether to update an existing zip file or not."
+        "description": "The file path for where the zip file should be created.",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "E:\\Testing\\TestingLogs.zip",
+        "placeholderQuote": "'"
       },
       {
         "name": "Force",
-        "description": "Specifies whether an existing zip file should be overwritten."
+        "description": "Specifies whether an existing zip file should be overwritten.",
+        "required": false,
+        "isSwitch": true,
+        "type": "System.Management.Automation.SwitchParameter",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "LiteralPath",
+        "description": "One or more literal paths to compress.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "Path",
+        "description": "One or more paths to compress. Supports wildcards.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "RemoveSourceAfterArchiving",
-        "description": "Remove the source path after successfully archiving the content."
+        "description": "Remove the source path after successfully archiving the content.",
+        "required": false,
+        "isSwitch": true,
+        "type": "System.Management.Automation.SwitchParameter",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "Update",
+        "description": "Specifies whether to update an existing zip file or not.",
+        "required": false,
+        "isSwitch": true,
+        "type": "System.Management.Automation.SwitchParameter",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       }
     ]
   },
@@ -1337,164 +2909,484 @@
     "link": "https://psappdeploytoolkit.com/docs/reference/functions/Open-ADTSession",
     "parameters": [
       {
-        "name": "SessionState",
-        "description": "Defaults to $PSCmdlet.SessionState to get the caller's SessionState, so only required if you need to override this."
-      },
-      {
-        "name": "DeploymentType",
-        "description": "Specifies the type of deployment: Install, Uninstall, or Repair."
-      },
-      {
-        "name": "DeployMode",
-        "description": "Specifies the deployment mode: Interactive, NonInteractive, or Silent."
-      },
-      {
-        "name": "SuppressRebootPassThru",
-        "description": "Suppresses reboot pass-through."
-      },
-      {
-        "name": "TerminalServerMode",
-        "description": "Enables Terminal Server mode."
-      },
-      {
-        "name": "DisableLogging",
-        "description": "Disables logging for the session."
-      },
-      {
-        "name": "AppVendor",
-        "description": "Specifies the application vendor."
-      },
-      {
-        "name": "AppName",
-        "description": "Specifies the application name."
-      },
-      {
-        "name": "AppVersion",
-        "description": "Specifies the application version."
-      },
-      {
         "name": "AppArch",
-        "description": "Specifies the application architecture."
+        "description": "Specifies the application architecture.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "AppLang",
-        "description": "Specifies the application language."
+        "description": "Specifies the application language.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
-        "name": "AppRevision",
-        "description": "Specifies the application revision."
-      },
-      {
-        "name": "AppScriptVersion",
-        "description": "Specifies the application script version."
-      },
-      {
-        "name": "AppScriptDate",
-        "description": "Specifies the application script date."
-      },
-      {
-        "name": "AppScriptAuthor",
-        "description": "Specifies the application script author."
-      },
-      {
-        "name": "InstallName",
-        "description": "Specifies the install name."
-      },
-      {
-        "name": "InstallTitle",
-        "description": "Specifies the install title."
-      },
-      {
-        "name": "DeployAppScriptFriendlyName",
-        "description": "Specifies the friendly name of the deploy application script."
-      },
-      {
-        "name": "DeployAppScriptVersion",
-        "description": "Specifies the version of the deploy application script."
-      },
-      {
-        "name": "DeployAppScriptParameters",
-        "description": "Specifies the parameters for the deploy application script."
-      },
-      {
-        "name": "AppSuccessExitCodes",
-        "description": "Specifies the application exit codes."
-      },
-      {
-        "name": "AppRebootExitCodes",
-        "description": "Specifies the application reboot codes."
+        "name": "AppName",
+        "description": "Specifies the application name.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "AppProcessesToClose",
-        "description": "Specifies one or more processes that require closing to ensure a successful deployment."
+        "description": "Specifies one or more processes that require closing to ensure a successful deployment.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
-        "name": "RequireAdmin",
-        "description": "Specifies that this deployment requires administrative permissions."
+        "name": "AppRebootExitCodes",
+        "description": "Specifies the application reboot codes.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
-        "name": "ScriptDirectory",
-        "description": "Specifies the base path for Files and SupportFiles."
+        "name": "AppRevision",
+        "description": "Specifies the application revision.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
-        "name": "DirFiles",
-        "description": "Specifies the override path to Files."
+        "name": "AppScriptAuthor",
+        "description": "Specifies the application script author.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
-        "name": "DirSupportFiles",
-        "description": "Specifies the override path to SupportFiles."
+        "name": "AppScriptDate",
+        "description": "Specifies the application script date.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "AppScriptVersion",
+        "description": "Specifies the application script version.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "AppSuccessExitCodes",
+        "description": "Specifies the application exit codes.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "AppVendor",
+        "description": "Specifies the application vendor.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "AppVersion",
+        "description": "Specifies the application version.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "DefaultMsiFile",
-        "description": "Specifies the default MSI file."
-      },
-      {
-        "name": "DefaultMstFile",
-        "description": "Specifies the default MST file."
+        "description": "Specifies the default MSI file.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "DefaultMspFiles",
-        "description": "Specifies the default MSP files."
+        "description": "Specifies the default MSP files.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "DefaultMstFile",
+        "description": "Specifies the default MST file.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "DeployAppScriptFriendlyName",
+        "description": "Specifies the friendly name of the deploy application script.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "DeployAppScriptParameters",
+        "description": "Specifies the parameters for the deploy application script.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "DeployAppScriptVersion",
+        "description": "Specifies the version of the deploy application script.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "DeploymentType",
+        "description": "Specifies the type of deployment: Install, Uninstall, or Repair.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "Install",
+        "placeholderQuote": "\""
+      },
+      {
+        "name": "DeployMode",
+        "description": "Specifies the deployment mode: Interactive, NonInteractive, or Silent.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "Interactive",
+        "placeholderQuote": "\""
+      },
+      {
+        "name": "DirFiles",
+        "description": "Specifies the override path to Files.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "DirSupportFiles",
+        "description": "Specifies the override path to SupportFiles.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "DisableDefaultMsiProcessList",
-        "description": "Specifies that the zero-config MSI code should not gather process names from the MSI file."
+        "description": "Specifies that the zero-config MSI code should not gather process names from the MSI file.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "DisableLogging",
+        "description": "Disables logging for the session.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "ForceMsiDetection",
-        "description": "Specifies that MSI files should be detected and parsed during session initialization, irrespective of whether any App values are provided."
+        "description": "Specifies that MSI files should be detected and parsed during session initialization, irrespective of whether any App values are provided.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "ForceWimDetection",
-        "description": "Specifies that WIM files should be detected and mounted during session initialization, irrespective of whether any App values are provided."
+        "description": "Specifies that WIM files should be detected and mounted during session initialization, irrespective of whether any App values are provided.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
-        "name": "NoSessionDetection",
-        "description": "When DeployMode is not specified or is Auto, bypasses DeployMode adjustment when there's no logged on user session available."
+        "name": "InstallName",
+        "description": "Specifies the install name.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
-        "name": "NoOobeDetection",
-        "description": "When DeployMode is not specified or is Auto, bypasses DeployMode adjustment when the device hasn't completed the OOBE or a user ESP is active."
-      },
-      {
-        "name": "NoProcessDetection",
-        "description": "When DeployMode is not specified or is Auto, bypasses DeployMode adjustment when there's no processes to close in the specified AppProcessesToClose list."
-      },
-      {
-        "name": "PassThru",
-        "description": "Passes the session object through the pipeline."
+        "name": "InstallTitle",
+        "description": "Specifies the install title.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "LogName",
-        "description": "Specifies an override for the default-generated log file name."
+        "description": "Specifies an override for the default-generated log file name.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "NoOobeDetection",
+        "description": "When DeployMode is not specified or is Auto, bypasses DeployMode adjustment when the device hasn't completed the OOBE or a user ESP is active.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "NoProcessDetection",
+        "description": "When DeployMode is not specified or is Auto, bypasses DeployMode adjustment when there's no processes to close in the specified AppProcessesToClose list.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "NoSessionDetection",
+        "description": "When DeployMode is not specified or is Auto, bypasses DeployMode adjustment when there's no logged on user session available.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "PassThru",
+        "description": "Passes the session object through the pipeline.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "RequireAdmin",
+        "description": "Specifies that this deployment requires administrative permissions.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "ScriptDirectory",
+        "description": "Specifies the base path for Files and SupportFiles.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "SessionClass",
-        "description": "Specifies an override for PSADT.Module.DeploymentSession class. Use this if you're deriving a class inheriting off PSAppDeployToolkit's base."
+        "description": "Specifies an override for PSADT.Module.DeploymentSession class. Use this if you're deriving a class inheriting off PSAppDeployToolkit's base.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "SessionState",
+        "description": "Defaults to $PSCmdlet.SessionState to get the caller's SessionState, so only required if you need to override this.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "$ExecutionContext.SessionState",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "SuppressRebootPassThru",
+        "description": "Suppresses reboot pass-through.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "TerminalServerMode",
+        "description": "Enables Terminal Server mode.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "UnboundArguments",
-        "description": "Captures any additional arguments passed to the function."
+        "description": "Captures any additional arguments passed to the function.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       }
     ]
   },
@@ -1506,7 +3398,15 @@
     "parameters": [
       {
         "name": "Command",
-        "description": "The PowerShell command to be encoded."
+        "description": "The PowerShell command to be encoded.",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "Get-Process",
+        "placeholderQuote": "'"
       }
     ]
   },
@@ -1518,7 +3418,15 @@
     "parameters": [
       {
         "name": "FilePath",
-        "description": "Path to the DLL file."
+        "description": "Path to the DLL file.",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "C:\\Test\\DcTLSFileToDMSComp.dll",
+        "placeholderQuote": "\""
       }
     ]
   },
@@ -1530,7 +3438,15 @@
     "parameters": [
       {
         "name": "LiteralPath",
-        "description": "The path to the software cache folder."
+        "description": "The path to the software cache folder.",
+        "required": false,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "$((& $Script:CommandTable.'Get-ADTConfig').Toolkit.CachePath)\\$((& $Script:CommandTable.'Get-ADTSession').InstallName)",
+        "defaultRaw": "\"$((& $Script:CommandTable.'Get-ADTConfig').Toolkit.CachePath)\\$((& $Script:CommandTable.'Get-ADTSession').InstallName)\"",
+        "defaultQuote": "\"",
+        "placeholder": "$envWinDir\\Temp\\PSAppDeployToolkit",
+        "placeholderQuote": "\""
       }
     ]
   },
@@ -1542,7 +3458,15 @@
     "parameters": [
       {
         "name": "ExtensionID",
-        "description": "The ID of the extension to remove."
+        "description": "The ID of the extension to remove.",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "extensionID",
+        "placeholderQuote": "\""
       }
     ]
   },
@@ -1553,12 +3477,28 @@
     "link": "https://psappdeploytoolkit.com/docs/reference/functions/Remove-ADTEnvironmentVariable",
     "parameters": [
       {
-        "name": "Variable",
-        "description": "The variable to remove."
+        "name": "Target",
+        "description": "The target of the variable to remove. This can be the machine, user, or process.",
+        "required": false,
+        "isSwitch": false,
+        "type": "System.EnvironmentVariableTarget",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "Machine",
+        "placeholderQuote": ""
       },
       {
-        "name": "Target",
-        "description": "The target of the variable to remove. This can be the machine, user, or process."
+        "name": "Variable",
+        "description": "The variable to remove.",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "Path",
+        "placeholderQuote": ""
       }
     ]
   },
@@ -1569,16 +3509,40 @@
     "link": "https://psappdeploytoolkit.com/docs/reference/functions/Remove-ADTFile",
     "parameters": [
       {
-        "name": "Path",
-        "description": "Specifies the file on the filesystem to be removed. The value of Path will accept wildcards. Will accept an array of values."
+        "name": "LiteralPath",
+        "description": "Specifies the file on the filesystem to be removed. The value of LiteralPath is used exactly as it is typed; no characters are interpreted as wildcards. Will accept an array of values.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "C:\\Windows\\Downloaded Program Files\\Temp.inf",
+        "placeholderQuote": "'"
       },
       {
-        "name": "LiteralPath",
-        "description": "Specifies the file on the filesystem to be removed. The value of LiteralPath is used exactly as it is typed; no characters are interpreted as wildcards. Will accept an array of values."
+        "name": "Path",
+        "description": "Specifies the file on the filesystem to be removed. The value of Path will accept wildcards. Will accept an array of values.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "Recurse",
-        "description": "Deletes the files in the specified location(s) and in all child items of the location(s)."
+        "description": "Deletes the files in the specified location(s) and in all child items of the location(s).",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       }
     ]
   },
@@ -1589,32 +3553,88 @@
     "link": "https://psappdeploytoolkit.com/docs/reference/functions/Remove-ADTFileFromUserProfiles",
     "parameters": [
       {
-        "name": "Path",
-        "description": "Specifies the path to append to the root of the user profile to be resolved. The value of Path will accept wildcards. Will accept an array of values."
-      },
-      {
-        "name": "LiteralPath",
-        "description": "Specifies the path to append to the root of the user profile to be resolved. The value of LiteralPath is used exactly as it is typed; no characters are interpreted as wildcards. Will accept an array of values."
-      },
-      {
-        "name": "Recurse",
-        "description": "Deletes the files in the specified location(s) and in all child items of the location(s)."
+        "name": "ExcludeDefaultUser",
+        "description": "Exclude the Default User.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "ExcludeNTAccount",
-        "description": "Specify NT account names in Domain\\Username format to exclude from the list of user profiles."
-      },
-      {
-        "name": "ExcludeDefaultUser",
-        "description": "Exclude the Default User."
-      },
-      {
-        "name": "IncludeSystemProfiles",
-        "description": "Include system profiles: SYSTEM, LOCAL SERVICE, NETWORK SERVICE."
+        "description": "Specify NT account names in Domain\\Username format to exclude from the list of user profiles.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "IncludeServiceProfiles",
-        "description": "Include service profiles where NTAccount begins with NT SERVICE."
+        "description": "Include service profiles where NTAccount begins with NT SERVICE.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "IncludeSystemProfiles",
+        "description": "Include system profiles: SYSTEM, LOCAL SERVICE, NETWORK SERVICE.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "LiteralPath",
+        "description": "Specifies the path to append to the root of the user profile to be resolved. The value of LiteralPath is used exactly as it is typed; no characters are interpreted as wildcards. Will accept an array of values.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "Path",
+        "description": "Specifies the path to append to the root of the user profile to be resolved. The value of Path will accept wildcards. Will accept an array of values.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "AppData\\Roaming\\MyApp\\config.txt",
+        "placeholderQuote": "\""
+      },
+      {
+        "name": "Recurse",
+        "description": "Deletes the files in the specified location(s) and in all child items of the location(s).",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       }
     ]
   },
@@ -1625,20 +3645,52 @@
     "link": "https://psappdeploytoolkit.com/docs/reference/functions/Remove-ADTFolder",
     "parameters": [
       {
-        "name": "Path",
-        "description": "A path to the folder to remove. Can contain wildcards."
-      },
-      {
-        "name": "LiteralPath",
-        "description": "A literal path to the folder to remove."
+        "name": "DisableRecursion",
+        "description": "Disables recursion while deleting.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "InputObject",
-        "description": "A DirectoryInfo object to remove. Available for pipelining."
+        "description": "A DirectoryInfo object to remove. Available for pipelining.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
-        "name": "DisableRecursion",
-        "description": "Disables recursion while deleting."
+        "name": "LiteralPath",
+        "description": "A literal path to the folder to remove.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "Path",
+        "description": "A path to the folder to remove. Can contain wildcards.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "$envWinDir\\Downloaded Program Files",
+        "placeholderQuote": "\""
       }
     ]
   },
@@ -1650,7 +3702,15 @@
     "parameters": [
       {
         "name": "Hashtable",
-        "description": "The hashtable to remove null values from."
+        "description": "The hashtable to remove null values from.",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.Collections.Hashtable",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       }
     ]
   },
@@ -1662,11 +3722,27 @@
     "parameters": [
       {
         "name": "FilePath",
-        "description": "Path to the INI file."
+        "description": "Path to the INI file.",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "$env:ProgramFilesX86\\IBM\\Notes\\notes.ini",
+        "placeholderQuote": "\""
       },
       {
         "name": "Section",
-        "description": "Section within the INI file."
+        "description": "Section within the INI file.",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "Notes",
+        "placeholderQuote": "'"
       }
     ]
   },
@@ -1678,15 +3754,39 @@
     "parameters": [
       {
         "name": "FilePath",
-        "description": "Path to the INI file."
-      },
-      {
-        "name": "Section",
-        "description": "Section within the INI file."
+        "description": "Path to the INI file.",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "$env:ProgramFilesX86\\IBM\\Notes\\notes.ini",
+        "placeholderQuote": "\""
       },
       {
         "name": "Key",
-        "description": "Key within the section of the INI file."
+        "description": "Key within the section of the INI file.",
+        "required": false,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "KeyFileName",
+        "placeholderQuote": "'"
+      },
+      {
+        "name": "Section",
+        "description": "Section within the INI file.",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "Notes",
+        "placeholderQuote": "'"
       }
     ]
   },
@@ -1698,7 +3798,15 @@
     "parameters": [
       {
         "name": "Name",
-        "description": "Text to remove invalid filename characters from."
+        "description": "Text to remove invalid filename characters from.",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "Filename/\\1",
+        "placeholderQuote": "\""
       }
     ]
   },
@@ -1709,12 +3817,28 @@
     "link": "https://psappdeploytoolkit.com/docs/reference/functions/Remove-ADTModuleCallback",
     "parameters": [
       {
-        "name": "Hookpoint",
-        "description": "Where you wish for the callback to be removed from."
+        "name": "Callback",
+        "description": "The callback function to remove from the nominated hooking point.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "(Get-Command",
+        "placeholderQuote": ""
       },
       {
-        "name": "Callback",
-        "description": "The callback function to remove from the nominated hooking point."
+        "name": "Hookpoint",
+        "description": "Where you wish for the callback to be removed from.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "PostOpen",
+        "placeholderQuote": ""
       }
     ]
   },
@@ -1725,28 +3849,76 @@
     "link": "https://psappdeploytoolkit.com/docs/reference/functions/Remove-ADTRegistryKey",
     "parameters": [
       {
-        "name": "Path",
-        "description": "Path of the registry key to delete, wildcards permitted."
-      },
-      {
         "name": "LiteralPath",
-        "description": "Literal path of the registry key to delete."
+        "description": "Literal path of the registry key to delete.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "Name",
-        "description": "Name of the registry value to delete."
+        "description": "Name of the registry value to delete.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "RunAppInstall",
+        "placeholderQuote": "'"
       },
       {
-        "name": "Wow6432Node",
-        "description": "Specify this switch to read the 32-bit registry (Wow6432Node) on 64-bit systems."
+        "name": "Path",
+        "description": "Path of the registry key to delete, wildcards permitted.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "Recurse",
-        "description": "Delete registry key recursively."
+        "description": "Delete registry key recursively.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "SID",
-        "description": "The security identifier (SID) for a user. Specifying this parameter will convert a HKEY_CURRENT_USER registry key to the HKEY_USERS\\$SID format. Specify this parameter from the Invoke-ADTAllUsersRegistryAction function to read/edit HKCU registry settings for all users on the system."
+        "description": "The security identifier (SID) for a user. Specifying this parameter will convert a HKEY_CURRENT_USER registry key to the HKEY_USERS\\$SID format. Specify this parameter from the Invoke-ADTAllUsersRegistryAction function to read/edit HKCU registry settings for all users on the system.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "Wow6432Node",
+        "description": "Specify this switch to read the 32-bit registry (Wow6432Node) on 64-bit systems.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       }
     ]
   },
@@ -1765,27 +3937,75 @@
     "parameters": [
       {
         "name": "ErrorRecord",
-        "description": "The ErrorRecord to resolve. For usage in a catch block, you'd use the automatic variable `$PSItem`. For usage out of a catch block, you can access the global $Error array's first error (on index 0)."
-      },
-      {
-        "name": "Property",
-        "description": "The list of properties to display from the ErrorRecord. Use \"*\" to display all properties."
-      },
-      {
-        "name": "ExcludeErrorRecord",
-        "description": "Exclude ErrorRecord details as represented by $ErrorRecord."
-      },
-      {
-        "name": "ExcludeErrorInvocation",
-        "description": "Exclude ErrorRecord invocation information as represented by $ErrorRecord.InvocationInfo."
+        "description": "The ErrorRecord to resolve. For usage in a catch block, you'd use the automatic variable `$PSItem`. For usage out of a catch block, you can access the global $Error array's first error (on index 0).",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.Management.Automation.ErrorRecord",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "ExcludeErrorException",
-        "description": "Exclude ErrorRecord exception details as represented by $ErrorRecord.Exception."
+        "description": "Exclude ErrorRecord exception details as represented by $ErrorRecord.Exception.",
+        "required": false,
+        "isSwitch": true,
+        "type": "System.Management.Automation.SwitchParameter",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "ExcludeErrorInvocation",
+        "description": "Exclude ErrorRecord invocation information as represented by $ErrorRecord.InvocationInfo.",
+        "required": false,
+        "isSwitch": true,
+        "type": "System.Management.Automation.SwitchParameter",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "ExcludeErrorRecord",
+        "description": "Exclude ErrorRecord details as represented by $ErrorRecord.",
+        "required": false,
+        "isSwitch": true,
+        "type": "System.Management.Automation.SwitchParameter",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "IncludeErrorInnerException",
-        "description": "Includes further ErrorRecord inner exception details as represented by $ErrorRecord.Exception.InnerException. Will retrieve all inner exceptions if there is more than one."
+        "description": "Includes further ErrorRecord inner exception details as represented by $ErrorRecord.Exception.InnerException. Will retrieve all inner exceptions if there is more than one.",
+        "required": false,
+        "isSwitch": true,
+        "type": "System.Management.Automation.SwitchParameter",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "Property",
+        "description": "The list of properties to display from the ErrorRecord. Use \"*\" to display all properties.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "*",
+        "placeholderQuote": ""
       }
     ]
   },
@@ -1796,28 +4016,76 @@
     "link": "http://msdn.microsoft.com/en-us/library/System.Windows.Forms.SendKeys(v=vs.100).aspx",
     "parameters": [
       {
-        "name": "WindowTitle",
-        "description": "The title of the application window to search for using regex matching."
-      },
-      {
         "name": "GetAllWindowTitles",
-        "description": "Get titles for all open windows on the system."
-      },
-      {
-        "name": "WindowHandle",
-        "description": "Send keys to a specific window where the Window Handle is already known."
+        "description": "Get titles for all open windows on the system.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "Keys",
-        "description": "The sequence of keys to send. Info on Key input at: http://msdn.microsoft.com/en-us/library/System.Windows.Forms.SendKeys(v=vs.100).aspx"
-      },
-      {
-        "name": "WaitSeconds",
-        "description": "This parameter is obsolete and will be removed in PSAppDeployToolkit 4.2.0. Please use `-WaitDuration` instead."
+        "description": "The sequence of keys to send. Info on Key input at: http://msdn.microsoft.com/en-us/library/System.Windows.Forms.SendKeys(v=vs.100).aspx",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "Hello world",
+        "placeholderQuote": "'"
       },
       {
         "name": "WaitDuration",
-        "description": "An optional amount of time to wait after the sending of the keys."
+        "description": "An optional amount of time to wait after the sending of the keys.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "WaitSeconds",
+        "description": "This parameter is obsolete and will be removed in PSAppDeployToolkit 4.2.0. Please use `-WaitDuration` instead.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "WindowHandle",
+        "description": "Send keys to a specific window where the Window Handle is already known.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "([IntPtr]17368294)",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "WindowTitle",
+        "description": "The title of the application window to search for using regex matching.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "foobar - Notepad",
+        "placeholderQuote": "'"
       }
     ]
   },
@@ -1828,44 +4096,124 @@
     "link": "https://psappdeploytoolkit.com/docs/reference/functions/Set-ADTActiveSetup",
     "parameters": [
       {
-        "name": "StubExePath",
-        "description": "Use this parameter to specify the destination path of the file that will be executed upon user login. Note: Place the file you want users to execute in the '\\Files' subdirectory of the script directory and the toolkit will install it to the path specificed in this parameter."
-      },
-      {
         "name": "Arguments",
-        "description": "Arguments to pass to the file being executed."
-      },
-      {
-        "name": "Wow6432Node",
-        "description": "Specify this switch to use Active Setup entry under Wow6432Node on a 64-bit OS."
-      },
-      {
-        "name": "ExecutionPolicy",
-        "description": "Specifies the ExecutionPolicy to set when StubExePath is a PowerShell script."
-      },
-      {
-        "name": "Version",
-        "description": "Optional. Specify version for Active setup entry. Active Setup is not triggered if Version value has more than 8 consecutive digits. Use commas to get around this limitation. Note: - Do not use this parameter if it is not necessary. PSADT will handle this parameter automatically using the time of the installation as the version number. - In Windows 10, scripts and executables might be blocked by AppLocker. Ensure that the path given to -StubExePath will permit end users to run scripts and executables unelevated."
-      },
-      {
-        "name": "Locale",
-        "description": "Optional. Arbitrary string used to specify the installation language of the file being executed. Not replicated to HKCU."
-      },
-      {
-        "name": "PurgeActiveSetupKey",
-        "description": "Remove Active Setup entry from HKLM registry hive. Will also load each logon user's HKCU registry hive to remove Active Setup entry. Function returns after purging."
+        "description": "Arguments to pass to the file being executed.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "/Silent",
+        "placeholderQuote": "'"
       },
       {
         "name": "DisableActiveSetup",
-        "description": "Disables the Active Setup entry so that the StubPath file will not be executed. This also enables -NoExecuteForCurrentUser."
+        "description": "Disables the Active Setup entry so that the StubPath file will not be executed. This also enables -NoExecuteForCurrentUser.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "ExecutionPolicy",
+        "description": "Specifies the ExecutionPolicy to set when StubExePath is a PowerShell script.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "Locale",
+        "description": "Optional. Arbitrary string used to specify the installation language of the file being executed. Not replicated to HKCU.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "en",
+        "placeholderQuote": "'"
       },
       {
         "name": "NoExecuteForCurrentUser",
-        "description": "Specifies whether the StubExePath should be executed for the current user. Since this user is already logged in, the user won't have the application started without logging out and logging back in."
+        "description": "Specifies whether the StubExePath should be executed for the current user. Since this user is already logged in, the user won't have the application started without logging out and logging back in.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "PassThru",
-        "description": "Returns a ProcessResult from the execution of the ActiveSetup configuration for the current user if `-PassThru` is provided."
+        "description": "Returns a ProcessResult from the execution of the ActiveSetup configuration for the current user if `-PassThru` is provided.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "PurgeActiveSetupKey",
+        "description": "Remove Active Setup entry from HKLM registry hive. Will also load each logon user's HKCU registry hive to remove Active Setup entry. Function returns after purging.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "StubExePath",
+        "description": "Use this parameter to specify the destination path of the file that will be executed upon user login. Note: Place the file you want users to execute in the '\\Files' subdirectory of the script directory and the toolkit will install it to the path specificed in this parameter.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "C:\\Users\\Public\\Company\\ProgramUserConfig.vbs",
+        "placeholderQuote": "'"
+      },
+      {
+        "name": "Version",
+        "description": "Optional. Specify version for Active setup entry. Active Setup is not triggered if Version value has more than 8 consecutive digits. Use commas to get around this limitation. Note: - Do not use this parameter if it is not necessary. PSADT will handle this parameter automatically using the time of the installation as the version number. - In Windows 10, scripts and executables might be blocked by AppLocker. Ensure that the path given to -StubExePath will permit end users to run scripts and executables unelevated.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "Wow6432Node",
+        "description": "Specify this switch to use Active Setup entry under Wow6432Node on a 64-bit OS.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       }
     ]
   },
@@ -1874,7 +4222,68 @@
     "synopsis": "",
     "description": "",
     "link": "",
-    "parameters": []
+    "parameters": [
+      {
+        "name": "DisableActiveSetup",
+        "description": "",
+        "required": false,
+        "isSwitch": true,
+        "type": "System.Management.Automation.SwitchParameter",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "Locale",
+        "description": "",
+        "required": false,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "[System.Management.Automation.Language.NullString]::Value",
+        "defaultRaw": "[System.Management.Automation.Language.NullString]::Value",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "RegPath",
+        "description": "",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "SID",
+        "description": "",
+        "required": false,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "[System.Management.Automation.Language.NullString]::Value",
+        "defaultRaw": "[System.Management.Automation.Language.NullString]::Value",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "Version",
+        "description": "",
+        "required": false,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "[System.Management.Automation.Language.NullString]::Value",
+        "defaultRaw": "[System.Management.Automation.Language.NullString]::Value",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      }
+    ]
   },
   {
     "name": "Set-ADTDeferHistory",
@@ -1883,20 +4292,52 @@
     "link": "https://psappdeploytoolkit.com/docs/reference/functions/Set-ADTDeferHistory",
     "parameters": [
       {
-        "name": "DeferTimesRemaining",
-        "description": "Specify the number of deferrals remaining."
-      },
-      {
         "name": "DeferDeadline",
-        "description": "Specify the deadline for the deferral."
+        "description": "Specify the deadline for the deferral.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "DeferRunInterval",
-        "description": "Specifies the time span that must elapse before prompting the user again if a process listed in 'CloseProcesses' is still running after a deferral. This helps address the issue where Intune retries installations shortly after a user defers, preventing multiple immediate prompts and improving the user experience. This parameter is specifically utilized within the `Show-ADTInstallationWelcome` function, and if specified, the current date and time will be used for the DeferRunIntervalLastTime."
+        "description": "Specifies the time span that must elapse before prompting the user again if a process listed in 'CloseProcesses' is still running after a deferral. This helps address the issue where Intune retries installations shortly after a user defers, preventing multiple immediate prompts and improving the user experience. This parameter is specifically utilized within the `Show-ADTInstallationWelcome` function, and if specified, the current date and time will be used for the DeferRunIntervalLastTime.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "DeferRunIntervalLastTime",
-        "description": "Specifies the last time the DeferRunInterval value was tested. This is set from within `Show-ADTInstallationWelcome` as required."
+        "description": "Specifies the last time the DeferRunInterval value was tested. This is set from within `Show-ADTInstallationWelcome` as required.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "DeferTimesRemaining",
+        "description": "Specify the number of deferrals remaining.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       }
     ]
   },
@@ -1907,16 +4348,40 @@
     "link": "https://psappdeploytoolkit.com/docs/reference/functions/Set-ADTEnvironmentVariable",
     "parameters": [
       {
-        "name": "Variable",
-        "description": "The variable to set."
+        "name": "Target",
+        "description": "The target of the variable to set. This can be the machine, user, or process.",
+        "required": false,
+        "isSwitch": false,
+        "type": "System.EnvironmentVariableTarget",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "Machine",
+        "placeholderQuote": ""
       },
       {
         "name": "Value",
-        "description": "The value to set to variable to."
+        "description": "The value to set to variable to.",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "C:\\Windows",
+        "placeholderQuote": ""
       },
       {
-        "name": "Target",
-        "description": "The target of the variable to set. This can be the machine, user, or process."
+        "name": "Variable",
+        "description": "The variable to set.",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "Path",
+        "placeholderQuote": ""
       }
     ]
   },
@@ -1927,24 +4392,64 @@
     "link": "https://psappdeploytoolkit.com/docs/reference/functions/Set-ADTIniSection",
     "parameters": [
       {
-        "name": "FilePath",
-        "description": "Path to the INI file."
-      },
-      {
-        "name": "Section",
-        "description": "Section within the INI file."
-      },
-      {
         "name": "Content",
-        "description": "A hashtable or dictionary object containing the key-value pairs to set in the specified section. Supply an ordered hashtable to preserve the order of supplied entries. Values can be strings, numbers, booleans, enums, or null. Supply $null or an empty hashtable in combination with -Overwrite to empty an entire section."
+        "description": "A hashtable or dictionary object containing the key-value pairs to set in the specified section. Supply an ordered hashtable to preserve the order of supplied entries. Values can be strings, numbers, booleans, enums, or null. Supply $null or an empty hashtable in combination with -Overwrite to empty an entire section.",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.Collections.IDictionary",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "([ordered]@{'KeyFileName'",
+        "placeholderQuote": ""
       },
       {
-        "name": "Overwrite",
-        "description": "Specifies whether the provided INI content should overwrite all existing section content."
+        "name": "FilePath",
+        "description": "Path to the INI file.",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "$env:ProgramFilesX86\\IBM\\Notes\\notes.ini",
+        "placeholderQuote": "\""
       },
       {
         "name": "Force",
-        "description": "Specifies whether the INI file should be created if it does not already exist."
+        "description": "Specifies whether the INI file should be created if it does not already exist.",
+        "required": false,
+        "isSwitch": true,
+        "type": "System.Management.Automation.SwitchParameter",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "Overwrite",
+        "description": "Specifies whether the provided INI content should overwrite all existing section content.",
+        "required": false,
+        "isSwitch": true,
+        "type": "System.Management.Automation.SwitchParameter",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "Section",
+        "description": "Section within the INI file.",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "Notes",
+        "placeholderQuote": "'"
       }
     ]
   },
@@ -1956,23 +4461,63 @@
     "parameters": [
       {
         "name": "FilePath",
-        "description": "Path to the INI file."
-      },
-      {
-        "name": "Section",
-        "description": "Section within the INI file."
-      },
-      {
-        "name": "Key",
-        "description": "Key within the section of the INI file."
-      },
-      {
-        "name": "Value",
-        "description": "Value for the key within the section of the INI file."
+        "description": "Path to the INI file.",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "$env:ProgramFilesX86\\IBM\\Notes\\notes.ini",
+        "placeholderQuote": "\""
       },
       {
         "name": "Force",
-        "description": "Specifies whether the INI file should be created if it does not already exist."
+        "description": "Specifies whether the INI file should be created if it does not already exist.",
+        "required": false,
+        "isSwitch": true,
+        "type": "System.Management.Automation.SwitchParameter",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "Key",
+        "description": "Key within the section of the INI file.",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "KeyFileName",
+        "placeholderQuote": "'"
+      },
+      {
+        "name": "Section",
+        "description": "Section within the INI file.",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "Notes",
+        "placeholderQuote": "'"
+      },
+      {
+        "name": "Value",
+        "description": "Value for the key within the section of the INI file.",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "MyFile.ID",
+        "placeholderQuote": "'"
       }
     ]
   },
@@ -1983,48 +4528,136 @@
     "link": "https://psappdeploytoolkit.com/docs/reference/functions/Set-ADTItemPermission",
     "parameters": [
       {
-        "name": "LiteralPath",
-        "description": "Path to the folder or file you want to modify (ex: C:\\Temp)"
-      },
-      {
         "name": "AccessControlList",
-        "description": "The ACL object to apply to the given path."
-      },
-      {
-        "name": "User",
-        "description": "One or more user names (ex: BUILTIN\\Users, DOMAIN\\Admin) to give the permissions to. If you want to use SID, prefix it with an asterisk * (ex: *S-1-5-18)"
-      },
-      {
-        "name": "Permission",
-        "description": "Permission or list of permissions to be set/added/removed/replaced. Permission DeleteSubdirectoriesAndFiles does not apply to files."
-      },
-      {
-        "name": "PermissionType",
-        "description": "Sets Access Control Type of the permissions."
-      },
-      {
-        "name": "Inheritance",
-        "description": "Sets permission inheritance. Does not apply to files. Multiple options can be specified. * None - The permission entry is not inherited by child objects. * ObjectInherit - The permission entry is inherited by child leaf objects. * ContainerInherit - The permission entry is inherited by child container objects."
-      },
-      {
-        "name": "Propagation",
-        "description": "Sets how to propagate inheritance. Does not apply to files. * None - Specifies that no inheritance flags are set. * NoPropagateInherit - Specifies that the permission entry is not propagated to child objects. * InheritOnly - Specifies that the permission entry is propagated only to child objects. This includes both container and leaf child objects."
-      },
-      {
-        "name": "Method",
-        "description": "Specifies which method will be used to apply the permissions. * AddAccessRule - Adds permissions rules but it does not remove previous permissions. * SetAccessRule - Overwrites matching permission rules with new ones. * ResetAccessRule - Removes matching permissions rules and then adds permission rules. * RemoveAccessRule - Removes matching permission rules. * RemoveAccessRuleAll - Removes all permission rules for specified user/s. * RemoveAccessRuleSpecific - Removes specific permissions."
-      },
-      {
-        "name": "EnableInheritance",
-        "description": "Enables inheritance on the files/folders."
+        "description": "The ACL object to apply to the given path.",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.Security.AccessControl.FileSystemSecurity",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "DisableInheritance",
-        "description": "Disables inheritance, preserving permissions before doing so."
+        "description": "Disables inheritance, preserving permissions before doing so.",
+        "required": false,
+        "isSwitch": true,
+        "type": "System.Management.Automation.SwitchParameter",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "EnableInheritance",
+        "description": "Enables inheritance on the files/folders.",
+        "required": true,
+        "isSwitch": true,
+        "type": "System.Management.Automation.SwitchParameter",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "Inheritance",
+        "description": "Sets permission inheritance. Does not apply to files. Multiple options can be specified. * None - The permission entry is not inherited by child objects. * ObjectInherit - The permission entry is inherited by child leaf objects. * ContainerInherit - The permission entry is inherited by child container objects.",
+        "required": false,
+        "isSwitch": false,
+        "type": "System.Security.AccessControl.InheritanceFlags",
+        "defaultValue": "[System.Security.AccessControl.InheritanceFlags]::None",
+        "defaultRaw": "[System.Security.AccessControl.InheritanceFlags]::None",
+        "defaultQuote": "",
+        "placeholder": "ObjectInherit,ContainerInherit",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "LiteralPath",
+        "description": "Path to the folder or file you want to modify (ex: C:\\Temp)",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "C:\\Temp",
+        "placeholderQuote": "'"
+      },
+      {
+        "name": "Method",
+        "description": "Specifies which method will be used to apply the permissions. * AddAccessRule - Adds permissions rules but it does not remove previous permissions. * SetAccessRule - Overwrites matching permission rules with new ones. * ResetAccessRule - Removes matching permissions rules and then adds permission rules. * RemoveAccessRule - Removes matching permission rules. * RemoveAccessRuleAll - Removes all permission rules for specified user/s. * RemoveAccessRuleSpecific - Removes specific permissions.",
+        "required": false,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "AddAccessRule",
+        "defaultRaw": "'AddAccessRule'",
+        "defaultQuote": "'",
+        "placeholder": "RemoveAll",
+        "placeholderQuote": "'"
+      },
+      {
+        "name": "Permission",
+        "description": "Permission or list of permissions to be set/added/removed/replaced. Permission DeleteSubdirectoriesAndFiles does not apply to files.",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.Security.AccessControl.FileSystemRights",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "FullControl",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "PermissionType",
+        "description": "Sets Access Control Type of the permissions.",
+        "required": false,
+        "isSwitch": false,
+        "type": "System.Security.AccessControl.AccessControlType",
+        "defaultValue": "[System.Security.AccessControl.AccessControlType]::Allow",
+        "defaultRaw": "[System.Security.AccessControl.AccessControlType]::Allow",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "Propagation",
+        "description": "Sets how to propagate inheritance. Does not apply to files. * None - Specifies that no inheritance flags are set. * NoPropagateInherit - Specifies that the permission entry is not propagated to child objects. * InheritOnly - Specifies that the permission entry is propagated only to child objects. This includes both container and leaf child objects.",
+        "required": false,
+        "isSwitch": false,
+        "type": "System.Security.AccessControl.PropagationFlags",
+        "defaultValue": "[System.Security.AccessControl.PropagationFlags]::None",
+        "defaultRaw": "[System.Security.AccessControl.PropagationFlags]::None",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "RemoveExplicitRules",
-        "description": "Removes non-inherited permissions from the object when enabling inheritance."
+        "description": "Removes non-inherited permissions from the object when enabling inheritance.",
+        "required": false,
+        "isSwitch": true,
+        "type": "System.Management.Automation.SwitchParameter",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "User",
+        "description": "One or more user names (ex: BUILTIN\\Users, DOMAIN\\Admin) to give the permissions to. If you want to use SID, prefix it with an asterisk * (ex: *S-1-5-18)",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "DOMAIN\\John",
+        "placeholderQuote": "'"
       }
     ]
   },
@@ -2036,15 +4669,39 @@
     "parameters": [
       {
         "name": "Database",
-        "description": "Specify a ComObject representing an MSI database opened in view/modify/update mode."
+        "description": "Specify a ComObject representing an MSI database opened in view/modify/update mode.",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.__ComObject",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "$TempMsiPathDatabase",
+        "placeholderQuote": ""
       },
       {
         "name": "PropertyName",
-        "description": "The name of the property to be set/modified."
+        "description": "The name of the property to be set/modified.",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "ALLUSERS",
+        "placeholderQuote": "'"
       },
       {
         "name": "PropertyValue",
-        "description": "The value of the property to be set/modified."
+        "description": "The value of the property to be set/modified.",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "1",
+        "placeholderQuote": "'"
       }
     ]
   },
@@ -2056,7 +4713,15 @@
     "parameters": [
       {
         "name": "CultureInfo",
-        "description": "The culture to set the current thread's Culture and UICulture to. Can be a CultureInfo object, or any valid IETF BCP 47 language tag."
+        "description": "The culture to set the current thread's Culture and UICulture to. Can be a CultureInfo object, or any valid IETF BCP 47 language tag.",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.Globalization.CultureInfo",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       }
     ]
   },
@@ -2068,35 +4733,99 @@
     "parameters": [
       {
         "name": "LiteralPath",
-        "description": "The registry key path."
-      },
-      {
-        "name": "Name",
-        "description": "The value name."
-      },
-      {
-        "name": "Value",
-        "description": "The value data."
-      },
-      {
-        "name": "Type",
-        "description": "The type of registry value to create or set. DWord should be specified as a decimal."
+        "description": "The registry key path.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "MultiStringValueMode",
-        "description": "The mode to operate when working with MultiString objects. The default is replace, but add and remove modes are supported also."
+        "description": "The mode to operate when working with MultiString objects. The default is replace, but add and remove modes are supported also.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
-        "name": "Wow6432Node",
-        "description": "Specify this switch to write to the 32-bit registry (Wow6432Node) on 64-bit systems."
+        "name": "Name",
+        "description": "The value name.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "Debugger",
+        "placeholderQuote": "'"
       },
       {
         "name": "RegistryOptions",
-        "description": "Extra options to use while creating the key. This is useful for creating volatile keys that do not survive a reboot."
+        "description": "Extra options to use while creating the key. This is useful for creating volatile keys that do not survive a reboot.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "SID",
-        "description": "The security identifier (SID) for a user. Specifying this parameter will convert a HKEY_CURRENT_USER registry key to the HKEY_USERS\\$SID format. Specify this parameter from the Invoke-ADTAllUsersRegistryAction function to read/edit HKCU registry settings for all users on the system."
+        "description": "The security identifier (SID) for a user. Specifying this parameter will convert a HKEY_CURRENT_USER registry key to the HKEY_USERS\\$SID format. Specify this parameter from the Invoke-ADTAllUsersRegistryAction function to read/edit HKCU registry settings for all users on the system.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "Type",
+        "description": "The type of registry value to create or set. DWord should be specified as a decimal.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "DWord",
+        "placeholderQuote": "'"
+      },
+      {
+        "name": "Value",
+        "description": "The value data.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "$blockedAppDebuggerValue",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "Wow6432Node",
+        "description": "Specify this switch to write to the 32-bit registry (Wow6432Node) on 64-bit systems.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       }
     ]
   },
@@ -2108,11 +4837,27 @@
     "parameters": [
       {
         "name": "Service",
-        "description": "Specify the name of the service."
+        "description": "Specify the name of the service.",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.ServiceProcess.ServiceController",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "wuauserv",
+        "placeholderQuote": "'"
       },
       {
         "name": "StartMode",
-        "description": "Specify startup mode for the service. Options: Automatic, Automatic (Delayed Start), Manual, Disabled, Boot, System."
+        "description": "Specify startup mode for the service. Options: Automatic, Automatic (Delayed Start), Manual, Disabled, Boot, System.",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "Automatic (Delayed Start)",
+        "placeholderQuote": "'"
       }
     ]
   },
@@ -2123,44 +4868,124 @@
     "link": "https://psappdeploytoolkit.com/docs/reference/functions/Set-ADTShortcut",
     "parameters": [
       {
-        "name": "LiteralPath",
-        "description": "Path to the shortcut to be changed."
-      },
-      {
-        "name": "TargetPath",
-        "description": "Sets target path or URL that the shortcut launches."
-      },
-      {
         "name": "Arguments",
-        "description": "Sets the arguments used against the target path."
-      },
-      {
-        "name": "IconLocation",
-        "description": "Sets location of the icon used for the shortcut."
-      },
-      {
-        "name": "IconIndex",
-        "description": "Sets the index of the icon. Executables, DLLs, ICO files with multiple icons need the icon index to be specified. This parameter is an Integer. The first index is 0."
+        "description": "Sets the arguments used against the target path.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "Description",
-        "description": "Sets the description of the shortcut as can be seen in the shortcut's properties."
-      },
-      {
-        "name": "WorkingDirectory",
-        "description": "Sets working directory to be used for the target path."
-      },
-      {
-        "name": "WindowStyle",
-        "description": "Sets the shortcut's window style to be minimised, maximised, etc."
-      },
-      {
-        "name": "RunAsAdmin",
-        "description": "Sets the shortcut to require elevated permissions to run."
+        "description": "Sets the description of the shortcut as can be seen in the shortcut's properties.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "HotKey",
-        "description": "Sets the hotkey to launch the shortcut, e.g. \"CTRL+SHIFT+F\"."
+        "description": "Sets the hotkey to launch the shortcut, e.g. \"CTRL+SHIFT+F\".",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "IconIndex",
+        "description": "Sets the index of the icon. Executables, DLLs, ICO files with multiple icons need the icon index to be specified. This parameter is an Integer. The first index is 0.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "IconLocation",
+        "description": "Sets location of the icon used for the shortcut.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "LiteralPath",
+        "description": "Path to the shortcut to be changed.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "$envCommonDesktop\\Application.lnk",
+        "placeholderQuote": "\""
+      },
+      {
+        "name": "RunAsAdmin",
+        "description": "Sets the shortcut to require elevated permissions to run.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "TargetPath",
+        "description": "Sets target path or URL that the shortcut launches.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "$envProgramFiles\\Application\\application.exe",
+        "placeholderQuote": "\""
+      },
+      {
+        "name": "WindowStyle",
+        "description": "Sets the shortcut's window style to be minimised, maximised, etc.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "WorkingDirectory",
+        "description": "Sets working directory to be used for the target path.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       }
     ]
   },
@@ -2169,7 +4994,32 @@
     "synopsis": "",
     "description": "",
     "link": "",
-    "parameters": []
+    "parameters": [
+      {
+        "name": "Name",
+        "description": "",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "Value",
+        "description": "",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.Object",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      }
+    ]
   },
   {
     "name": "Show-ADTBalloonTip",
@@ -2178,24 +5028,64 @@
     "link": "https://psappdeploytoolkit.com/docs/reference/functions/Show-ADTBalloonTip",
     "parameters": [
       {
-        "name": "BalloonTipText",
-        "description": "Text of the balloon tip."
+        "name": "BalloonTipIcon",
+        "description": "Icon to be used. Options: 'Error', 'Info', 'None', 'Warning'.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "Info",
+        "placeholderQuote": "'"
       },
       {
-        "name": "BalloonTipIcon",
-        "description": "Icon to be used. Options: 'Error', 'Info', 'None', 'Warning'."
+        "name": "BalloonTipText",
+        "description": "Text of the balloon tip.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "Installation Started",
+        "placeholderQuote": "'"
       },
       {
         "name": "BalloonTipTime",
-        "description": "Time in milliseconds to display the balloon tip. Default: 10000."
-      },
-      {
-        "name": "NoWait",
-        "description": "Creates the balloon tip asynchronously."
+        "description": "Time in milliseconds to display the balloon tip. Default: 10000.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "Force",
-        "description": "Creates the balloon tip irrespective of whether running silently or not."
+        "description": "Creates the balloon tip irrespective of whether running silently or not.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "NoWait",
+        "description": "Creates the balloon tip asynchronously.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       }
     ]
   },
@@ -2206,36 +5096,100 @@
     "link": "https://psappdeploytoolkit.com/docs/reference/functions/Show-ADTDialogBox",
     "parameters": [
       {
-        "name": "Text",
-        "description": "Text in the message dialog box."
-      },
-      {
         "name": "Buttons",
-        "description": "The button(s) to display on the dialog box."
+        "description": "The button(s) to display on the dialog box.",
+        "required": false,
+        "isSwitch": false,
+        "type": "PSADT.UserInterface.Dialogs.DialogBoxButtons",
+        "defaultValue": "[PSADT.UserInterface.Dialogs.DialogBoxButtons]::Ok",
+        "defaultRaw": "[PSADT.UserInterface.Dialogs.DialogBoxButtons]::Ok",
+        "defaultQuote": "",
+        "placeholder": "OKCancel",
+        "placeholderQuote": "'"
       },
       {
         "name": "DefaultButton",
-        "description": "The Default button that is selected. Options: First, Second, Third."
-      },
-      {
-        "name": "Icon",
-        "description": "Icon to display on the dialog box. Options: None, Stop, Question, Exclamation, Information."
-      },
-      {
-        "name": "NoWait",
-        "description": "Presents the dialog in a separate, independent thread so that the main process isn't stalled waiting for a response."
+        "description": "The Default button that is selected. Options: First, Second, Third.",
+        "required": false,
+        "isSwitch": false,
+        "type": "PSADT.UserInterface.Dialogs.DialogBoxDefaultButton",
+        "defaultValue": "[PSADT.UserInterface.Dialogs.DialogBoxDefaultButton]::First",
+        "defaultRaw": "[PSADT.UserInterface.Dialogs.DialogBoxDefaultButton]::First",
+        "defaultQuote": "",
+        "placeholder": "Second",
+        "placeholderQuote": "'"
       },
       {
         "name": "ExitOnTimeout",
-        "description": "Specifies whether to not exit the script if the UI times out."
-      },
-      {
-        "name": "NotTopMost",
-        "description": "Specifies whether the message box shouldn't be a system modal message box that appears in a topmost window."
+        "description": "Specifies whether to not exit the script if the UI times out.",
+        "required": false,
+        "isSwitch": true,
+        "type": "System.Management.Automation.SwitchParameter",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "Force",
-        "description": "Specifies whether the message box should appear irrespective of an ongoing DeploymentSession's DeployMode."
+        "description": "Specifies whether the message box should appear irrespective of an ongoing DeploymentSession's DeployMode.",
+        "required": false,
+        "isSwitch": true,
+        "type": "System.Management.Automation.SwitchParameter",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "Icon",
+        "description": "Icon to display on the dialog box. Options: None, Stop, Question, Exclamation, Information.",
+        "required": false,
+        "isSwitch": false,
+        "type": "PSADT.UserInterface.Dialogs.DialogBoxIcon",
+        "defaultValue": "[PSADT.UserInterface.Dialogs.DialogBoxIcon]::None",
+        "defaultRaw": "[PSADT.UserInterface.Dialogs.DialogBoxIcon]::None",
+        "defaultQuote": "",
+        "placeholder": "Exclamation",
+        "placeholderQuote": "'"
+      },
+      {
+        "name": "NotTopMost",
+        "description": "Specifies whether the message box shouldn't be a system modal message box that appears in a topmost window.",
+        "required": false,
+        "isSwitch": true,
+        "type": "System.Management.Automation.SwitchParameter",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "NoWait",
+        "description": "Presents the dialog in a separate, independent thread so that the main process isn't stalled waiting for a response.",
+        "required": false,
+        "isSwitch": true,
+        "type": "System.Management.Automation.SwitchParameter",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "Text",
+        "description": "Text in the message dialog box.",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "Installation will take approximately 30 minutes. Do you wish to proceed?",
+        "placeholderQuote": "'"
       }
     ]
   },
@@ -2253,32 +5207,88 @@
     "link": "https://psappdeploytoolkit.com/docs/reference/functions/Show-ADTInstallationProgress",
     "parameters": [
       {
-        "name": "StatusMessage",
-        "description": "The status message to be displayed. The default status message is taken from the imported strings.psd1 file."
-      },
-      {
-        "name": "StatusMessageDetail",
-        "description": "The status message detail to be displayed with a fluent progress window. The default status message is taken from the imported strings.psd1 file."
-      },
-      {
-        "name": "StatusBarPercentage",
-        "description": "The percentage to display on the status bar. If null or not supplied, the status bar will continuously scroll."
+        "name": "AllowMove",
+        "description": "Specifies that the user can move the dialog on the screen.",
+        "required": false,
+        "isSwitch": true,
+        "type": "System.Management.Automation.SwitchParameter",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "MessageAlignment",
-        "description": "The text alignment to use for the status message."
-      },
-      {
-        "name": "WindowLocation",
-        "description": "The location of the dialog on the screen."
+        "description": "The text alignment to use for the status message.",
+        "required": false,
+        "isSwitch": false,
+        "type": "PSADT.UserInterface.Dialogs.DialogMessageAlignment",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "NotTopMost",
-        "description": "Specifies whether the progress window shouldn't be topmost."
+        "description": "Specifies whether the progress window shouldn't be topmost.",
+        "required": false,
+        "isSwitch": true,
+        "type": "System.Management.Automation.SwitchParameter",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
-        "name": "AllowMove",
-        "description": "Specifies that the user can move the dialog on the screen."
+        "name": "StatusBarPercentage",
+        "description": "The percentage to display on the status bar. If null or not supplied, the status bar will continuously scroll.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "StatusMessage",
+        "description": "The status message to be displayed. The default status message is taken from the imported strings.psd1 file.",
+        "required": false,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "[System.Management.Automation.Language.NullString]::Value",
+        "defaultRaw": "[System.Management.Automation.Language.NullString]::Value",
+        "defaultQuote": "",
+        "placeholder": "Installation in Progress...",
+        "placeholderQuote": "'"
+      },
+      {
+        "name": "StatusMessageDetail",
+        "description": "The status message detail to be displayed with a fluent progress window. The default status message is taken from the imported strings.psd1 file.",
+        "required": false,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "[System.Management.Automation.Language.NullString]::Value",
+        "defaultRaw": "[System.Management.Automation.Language.NullString]::Value",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "WindowLocation",
+        "description": "The location of the dialog on the screen.",
+        "required": false,
+        "isSwitch": false,
+        "type": "PSADT.UserInterface.Dialogs.DialogPosition",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "BottomRight",
+        "placeholderQuote": "'"
       }
     ]
   },
@@ -2289,64 +5299,184 @@
     "link": "https://psappdeploytoolkit.com/docs/reference/functions/Show-ADTInstallationPrompt",
     "parameters": [
       {
-        "name": "RequestInput",
-        "description": "Show a text box for the user to provide an answer."
-      },
-      {
-        "name": "DefaultValue",
-        "description": "The default value to show in the text box."
-      },
-      {
-        "name": "Message",
-        "description": "The message text to be displayed on the prompt."
-      },
-      {
-        "name": "MessageAlignment",
-        "description": "Alignment of the message text."
+        "name": "AllowMove",
+        "description": "Specifies that the user can move the dialog on the screen.",
+        "required": false,
+        "isSwitch": true,
+        "type": "System.Management.Automation.SwitchParameter",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "ButtonLeftText",
-        "description": "Show a button on the left of the prompt with the specified text."
-      },
-      {
-        "name": "ButtonRightText",
-        "description": "Show a button on the right of the prompt with the specified text."
+        "description": "Show a button on the left of the prompt with the specified text.",
+        "required": false,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "[System.Management.Automation.Language.NullString]::Value",
+        "defaultRaw": "[System.Management.Automation.Language.NullString]::Value",
+        "defaultQuote": "",
+        "placeholder": "Good",
+        "placeholderQuote": "'"
       },
       {
         "name": "ButtonMiddleText",
-        "description": "Show a button in the middle of the prompt with the specified text."
+        "description": "Show a button in the middle of the prompt with the specified text.",
+        "required": false,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "[System.Management.Automation.Language.NullString]::Value",
+        "defaultRaw": "[System.Management.Automation.Language.NullString]::Value",
+        "defaultQuote": "",
+        "placeholder": "Indifferent",
+        "placeholderQuote": "'"
+      },
+      {
+        "name": "ButtonRightText",
+        "description": "Show a button on the right of the prompt with the specified text.",
+        "required": false,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "[System.Management.Automation.Language.NullString]::Value",
+        "defaultRaw": "[System.Management.Automation.Language.NullString]::Value",
+        "defaultQuote": "",
+        "placeholder": "Bad",
+        "placeholderQuote": "'"
+      },
+      {
+        "name": "DefaultValue",
+        "description": "The default value to show in the text box.",
+        "required": false,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "[System.Management.Automation.Language.NullString]::Value",
+        "defaultRaw": "[System.Management.Automation.Language.NullString]::Value",
+        "defaultQuote": "",
+        "placeholder": "XXXX",
+        "placeholderQuote": "'"
       },
       {
         "name": "Icon",
-        "description": "Show a system icon in the prompt."
+        "description": "Show a system icon in the prompt.",
+        "required": false,
+        "isSwitch": false,
+        "type": "PSADT.UserInterface.Dialogs.DialogSystemIcon",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "Information",
+        "placeholderQuote": ""
       },
       {
-        "name": "WindowLocation",
-        "description": "The location of the dialog on the screen."
+        "name": "Message",
+        "description": "The message text to be displayed on the prompt.",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "[System.Management.Automation.Language.NullString]::Value",
+        "defaultRaw": "[System.Management.Automation.Language.NullString]::Value",
+        "defaultQuote": "",
+        "placeholder": "How are you feeling today?",
+        "placeholderQuote": "'"
       },
       {
-        "name": "NoWait",
-        "description": "Presents the dialog in a separate, independent thread so that the main process isn't stalled waiting for a response."
-      },
-      {
-        "name": "PersistPrompt",
-        "description": "Specify whether to make the prompt persist in the center of the screen every couple of seconds, specified in the config.psd1 file. The user will have no option but to respond to the prompt."
+        "name": "MessageAlignment",
+        "description": "Alignment of the message text.",
+        "required": false,
+        "isSwitch": false,
+        "type": "PSADT.UserInterface.Dialogs.DialogMessageAlignment",
+        "defaultValue": "[PSADT.UserInterface.Dialogs.DialogMessageAlignment]::Center",
+        "defaultRaw": "[PSADT.UserInterface.Dialogs.DialogMessageAlignment]::Center",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "MinimizeWindows",
-        "description": "Specifies whether to minimize other windows when displaying prompt."
+        "description": "Specifies whether to minimize other windows when displaying prompt.",
+        "required": false,
+        "isSwitch": true,
+        "type": "System.Management.Automation.SwitchParameter",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "NoExitOnTimeout",
-        "description": "Specifies whether to not exit the script if the UI times out."
+        "description": "Specifies whether to not exit the script if the UI times out.",
+        "required": false,
+        "isSwitch": true,
+        "type": "System.Management.Automation.SwitchParameter",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "NotTopMost",
-        "description": "Specifies whether the prompt shouldn't be topmost, above all other windows."
+        "description": "Specifies whether the prompt shouldn't be topmost, above all other windows.",
+        "required": false,
+        "isSwitch": true,
+        "type": "System.Management.Automation.SwitchParameter",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
-        "name": "AllowMove",
-        "description": "Specifies that the user can move the dialog on the screen."
+        "name": "NoWait",
+        "description": "Presents the dialog in a separate, independent thread so that the main process isn't stalled waiting for a response.",
+        "required": false,
+        "isSwitch": true,
+        "type": "System.Management.Automation.SwitchParameter",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "PersistPrompt",
+        "description": "Specify whether to make the prompt persist in the center of the screen every couple of seconds, specified in the config.psd1 file. The user will have no option but to respond to the prompt.",
+        "required": false,
+        "isSwitch": true,
+        "type": "System.Management.Automation.SwitchParameter",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "RequestInput",
+        "description": "Show a text box for the user to provide an answer.",
+        "required": true,
+        "isSwitch": true,
+        "type": "System.Management.Automation.SwitchParameter",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "-Message",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "WindowLocation",
+        "description": "The location of the dialog on the screen.",
+        "required": false,
+        "isSwitch": false,
+        "type": "PSADT.UserInterface.Dialogs.DialogPosition",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       }
     ]
   },
@@ -2357,40 +5487,112 @@
     "link": "https://psappdeploytoolkit.com/docs/reference/functions/Show-ADTInstallationRestartPrompt",
     "parameters": [
       {
-        "name": "CountdownSeconds",
-        "description": "Specifies the number of seconds to display the restart prompt."
+        "name": "AllowMove",
+        "description": "Specifies that the user can move the dialog on the screen.",
+        "required": false,
+        "isSwitch": true,
+        "type": "System.Management.Automation.SwitchParameter",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "CountdownNoHideSeconds",
-        "description": "Specifies the number of seconds to display the restart prompt without allowing the window to be hidden."
+        "description": "Specifies the number of seconds to display the restart prompt without allowing the window to be hidden.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "60",
+        "placeholderQuote": ""
       },
       {
-        "name": "SilentCountdownSeconds",
-        "description": "Specifies number of seconds to countdown for the restart when the toolkit is running in silent mode and `-SilentRestart` isn't specified."
-      },
-      {
-        "name": "SilentRestart",
-        "description": "Specifies whether the restart should be triggered when DeployMode is silent or very silent."
-      },
-      {
-        "name": "NoCountdown",
-        "description": "Specifies whether the user should receive a prompt to immediately restart their workstation."
-      },
-      {
-        "name": "WindowLocation",
-        "description": "The location of the dialog on the screen."
+        "name": "CountdownSeconds",
+        "description": "Specifies the number of seconds to display the restart prompt.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "300",
+        "placeholderQuote": ""
       },
       {
         "name": "CustomText",
-        "description": "Specify whether to display a custom message specified in the `strings.psd1` file. Custom message must be populated for each language section in the `strings.psd1` file."
+        "description": "Specify whether to display a custom message specified in the `strings.psd1` file. Custom message must be populated for each language section in the `strings.psd1` file.",
+        "required": false,
+        "isSwitch": true,
+        "type": "System.Management.Automation.SwitchParameter",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "NoCountdown",
+        "description": "Specifies whether the user should receive a prompt to immediately restart their workstation.",
+        "required": true,
+        "isSwitch": true,
+        "type": "System.Management.Automation.SwitchParameter",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "NotTopMost",
-        "description": "Specifies whether the prompt shouldn't be topmost, above all other windows."
+        "description": "Specifies whether the prompt shouldn't be topmost, above all other windows.",
+        "required": false,
+        "isSwitch": true,
+        "type": "System.Management.Automation.SwitchParameter",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
-        "name": "AllowMove",
-        "description": "Specifies that the user can move the dialog on the screen."
+        "name": "SilentCountdownSeconds",
+        "description": "Specifies number of seconds to countdown for the restart when the toolkit is running in silent mode and `-SilentRestart` isn't specified.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "SilentRestart",
+        "description": "Specifies whether the restart should be triggered when DeployMode is silent or very silent.",
+        "required": true,
+        "isSwitch": true,
+        "type": "System.Management.Automation.SwitchParameter",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "WindowLocation",
+        "description": "The location of the dialog on the screen.",
+        "required": false,
+        "isSwitch": false,
+        "type": "PSADT.UserInterface.Dialogs.DialogPosition",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       }
     ]
   },
@@ -2401,96 +5603,280 @@
     "link": "https://psappdeploytoolkit.com/docs/reference/functions/Show-ADTInstallationWelcome",
     "parameters": [
       {
-        "name": "CloseProcesses",
-        "description": "Name of the process to stop (do not include the .exe). Specify multiple processes separated by a comma. Specify custom descriptions like this: `@{ Name = 'winword'; Description = 'Microsoft Office Word' }, @{ Name = 'excel'; Description = 'Microsoft Office Excel' }`"
-      },
-      {
-        "name": "HideCloseButton",
-        "description": "Specifies that the 'Close Processes' button be hidden/disabled to force users to manually close down their running processes."
-      },
-      {
         "name": "AllowDefer",
-        "description": "Enables an optional defer button to allow the user to defer the deployment."
+        "description": "Enables an optional defer button to allow the user to defer the deployment.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "-DeferDeadline",
+        "placeholderQuote": ""
       },
       {
         "name": "AllowDeferCloseProcesses",
-        "description": "Enables an optional defer button to allow the user to defer the deployment only if there are running applications that need to be closed. This parameter automatically enables `-AllowDefer`."
-      },
-      {
-        "name": "Silent",
-        "description": "Stop processes without prompting the user."
-      },
-      {
-        "name": "CloseProcessesCountdown",
-        "description": "Option to provide a countdown in seconds until the specified applications are automatically closed. This only takes effect if deferral is not allowed or has expired."
-      },
-      {
-        "name": "ForceCloseProcessesCountdown",
-        "description": "Option to provide a countdown in seconds until the specified applications are automatically closed regardless of whether deferral is allowed."
-      },
-      {
-        "name": "ForceCountdown",
-        "description": "Specify a countdown to display before automatically proceeding with the deployment when a deferral is enabled."
-      },
-      {
-        "name": "DeferTimes",
-        "description": "Specify the number of times the deployment can be deferred."
-      },
-      {
-        "name": "DeferDays",
-        "description": "Specify the number of days since first run that the deployment can be deferred. This is converted to a deadline."
-      },
-      {
-        "name": "DeferDeadline",
-        "description": "Specify the deadline date until which the deployment can be deferred. Specify the date in the local culture if the script is intended for that same culture. If the script is intended to run on en-US machines, specify the date in the format: `08/25/2013`, or `08-25-2013`, or `08-25-2013 18:00:00`. If the script is intended for multiple cultures, specify the date in the universal sortable date/time format: `2013-08-22 11:51:52Z`. The deadline date will be displayed to the user in the format of their culture."
-      },
-      {
-        "name": "DeferRunInterval",
-        "description": "Specifies the time span that must elapse before prompting the user again if a process listed in 'CloseProcesses' is still running after a deferral. This addresses the issue where Intune retries deployments shortly after a user defers, preventing multiple immediate prompts and improving the user experience. Example: - To specify 30 minutes, use: `([System.TimeSpan]::FromMinutes(30))`. - To specify 24 hours, use: `([System.TimeSpan]::FromHours(24))`."
-      },
-      {
-        "name": "WindowLocation",
-        "description": "The location of the dialog on the screen."
-      },
-      {
-        "name": "BlockExecution",
-        "description": "Option to prevent the user from launching processes/applications, specified in -CloseProcesses, during the deployment."
-      },
-      {
-        "name": "PromptToSave",
-        "description": "Specify whether to prompt to save working documents when the user chooses to close applications by selecting the \"Close Programs\" button. Option does not work in SYSTEM context unless toolkit launched with \"psexec.exe -s -i\" to run it as an interactive process under the SYSTEM account."
-      },
-      {
-        "name": "PersistPrompt",
-        "description": "Specify whether to make the Show-ADTInstallationWelcome prompt persist in the center of the screen every couple of seconds, specified in the config.psd1. The user will have no option but to respond to the prompt. This only takes effect if deferral is not allowed or has expired."
-      },
-      {
-        "name": "MinimizeWindows",
-        "description": "Specifies whether to minimize other windows when displaying prompt."
-      },
-      {
-        "name": "NoMinimizeWindows",
-        "description": "This parameter will be removed in PSAppDeployToolkit 4.2.0."
-      },
-      {
-        "name": "NotTopMost",
-        "description": "Specifies whether the windows is the topmost window."
+        "description": "Enables an optional defer button to allow the user to defer the deployment only if there are running applications that need to be closed. This parameter automatically enables `-AllowDefer`.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "AllowMove",
-        "description": "Specifies that the user can move the dialog on the screen."
+        "description": "Specifies that the user can move the dialog on the screen.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
-        "name": "CustomText",
-        "description": "Specify whether to display a custom message as specified in the `strings.psd1` file below the main preamble. Custom message must be populated for each language section in the `strings.psd1` file."
+        "name": "BlockExecution",
+        "description": "Option to prevent the user from launching processes/applications, specified in -CloseProcesses, during the deployment.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "-AllowDefer",
+        "placeholderQuote": ""
       },
       {
         "name": "CheckDiskSpace",
-        "description": "Specify whether to check if there is enough disk space for the deployment to proceed. If this parameter is specified without the RequiredDiskSpace parameter, the required disk space is calculated automatically based on the size of the script source and associated files."
+        "description": "Specify whether to check if there is enough disk space for the deployment to proceed. If this parameter is specified without the RequiredDiskSpace parameter, the required disk space is calculated automatically based on the size of the script source and associated files.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "CloseProcesses",
+        "description": "Name of the process to stop (do not include the .exe). Specify multiple processes separated by a comma. Specify custom descriptions like this: `@{ Name = 'winword'; Description = 'Microsoft Office Word' }, @{ Name = 'excel'; Description = 'Microsoft Office Excel' }`",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "iexplore,",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "CloseProcessesCountdown",
+        "description": "Option to provide a countdown in seconds until the specified applications are automatically closed. This only takes effect if deferral is not allowed or has expired.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "600",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "CustomText",
+        "description": "Specify whether to display a custom message as specified in the `strings.psd1` file below the main preamble. Custom message must be populated for each language section in the `strings.psd1` file.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "DeferDays",
+        "description": "Specify the number of days since first run that the deployment can be deferred. This is converted to a deadline.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "DeferDeadline",
+        "description": "Specify the deadline date until which the deployment can be deferred. Specify the date in the local culture if the script is intended for that same culture. If the script is intended to run on en-US machines, specify the date in the format: `08/25/2013`, or `08-25-2013`, or `08-25-2013 18:00:00`. If the script is intended for multiple cultures, specify the date in the universal sortable date/time format: `2013-08-22 11:51:52Z`. The deadline date will be displayed to the user in the format of their culture.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "2013-08-25",
+        "placeholderQuote": "'"
+      },
+      {
+        "name": "DeferRunInterval",
+        "description": "Specifies the time span that must elapse before prompting the user again if a process listed in 'CloseProcesses' is still running after a deferral. This addresses the issue where Intune retries deployments shortly after a user defers, preventing multiple immediate prompts and improving the user experience. Example: - To specify 30 minutes, use: `([System.TimeSpan]::FromMinutes(30))`. - To specify 24 hours, use: `([System.TimeSpan]::FromHours(24))`.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "DeferTimes",
+        "description": "Specify the number of times the deployment can be deferred.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "10",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "ForceCloseProcessesCountdown",
+        "description": "Option to provide a countdown in seconds until the specified applications are automatically closed regardless of whether deferral is allowed.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "ForceCountdown",
+        "description": "Specify a countdown to display before automatically proceeding with the deployment when a deferral is enabled.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "HideCloseButton",
+        "description": "Specifies that the 'Close Processes' button be hidden/disabled to force users to manually close down their running processes.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "MinimizeWindows",
+        "description": "Specifies whether to minimize other windows when displaying prompt.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "NoMinimizeWindows",
+        "description": "This parameter will be removed in PSAppDeployToolkit 4.2.0.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "NotTopMost",
+        "description": "Specifies whether the windows is the topmost window.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "PersistPrompt",
+        "description": "Specify whether to make the Show-ADTInstallationWelcome prompt persist in the center of the screen every couple of seconds, specified in the config.psd1. The user will have no option but to respond to the prompt. This only takes effect if deferral is not allowed or has expired.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "PromptToSave",
+        "description": "Specify whether to prompt to save working documents when the user chooses to close applications by selecting the \"Close Programs\" button. Option does not work in SYSTEM context unless toolkit launched with \"psexec.exe -s -i\" to run it as an interactive process under the SYSTEM account.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "RequiredDiskSpace",
-        "description": "Specify required disk space in MB, used in combination with CheckDiskSpace."
+        "description": "Specify required disk space in MB, used in combination with CheckDiskSpace.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "Silent",
+        "description": "Stop processes without prompting the user.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "WindowLocation",
+        "description": "The location of the dialog on the screen.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       }
     ]
   },
@@ -2509,123 +5895,363 @@
     "parameters": [
       {
         "name": "Action",
-        "description": "Specifies the action to be performed. Available options: Install, Uninstall, Patch, Repair, ActiveSetup."
-      },
-      {
-        "name": "FilePath",
-        "description": "The file path to the MSI/MSP file."
-      },
-      {
-        "name": "ProductCode",
-        "description": "The product code of the installed MSI."
-      },
-      {
-        "name": "InstalledApplication",
-        "description": "The InstalledApplication object of the installed MSI."
-      },
-      {
-        "name": "ArgumentList",
-        "description": "Overrides the default parameters specified in the config.psd1 file."
+        "description": "Specifies the action to be performed. Available options: Install, Uninstall, Patch, Repair, ActiveSetup.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "Install",
+        "placeholderQuote": "'"
       },
       {
         "name": "AdditionalArgumentList",
-        "description": "Adds additional parameters to the default set specified in the config.psd1 file."
+        "description": "Adds additional parameters to the default set specified in the config.psd1 file.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
-        "name": "SecureArgumentList",
-        "description": "Hides all parameters passed to the MSI or MSP file from the toolkit log file."
-      },
-      {
-        "name": "WorkingDirectory",
-        "description": "Overrides the working directory. The working directory is set to the location of the MSI file."
-      },
-      {
-        "name": "Transforms",
-        "description": "The name(s) of the transform file(s) to be applied to the MSI. The transform files should be in the same directory as the MSI file."
-      },
-      {
-        "name": "Patches",
-        "description": "The name(s) of the patch (MSP) file(s) to be applied to the MSI for the \"Install\" action. The patch files should be in the same directory as the MSI file."
-      },
-      {
-        "name": "RunAsActiveUser",
-        "description": "A RunAsActiveUser object to invoke the process as."
-      },
-      {
-        "name": "UseLinkedAdminToken",
-        "description": "Use a user's linked administrative token while running the process under their context."
-      },
-      {
-        "name": "UseHighestAvailableToken",
-        "description": "Use a user's linked administrative token if it's available while running the process under their context."
-      },
-      {
-        "name": "InheritEnvironmentVariables",
-        "description": "Specifies whether the process running as a user should inherit the SYSTEM account's environment variables."
-      },
-      {
-        "name": "UseUnelevatedToken",
-        "description": "If the current process is elevated, starts the new process unelevated using the user's unelevated linked token."
-      },
-      {
-        "name": "ExpandEnvironmentVariables",
-        "description": "Specifies whether to expand any Windows/DOS-style environment variables in the specified FilePath/ArgumentList."
-      },
-      {
-        "name": "LoggingOptions",
-        "description": "Overrides the default logging options specified in the config.psd1 file."
-      },
-      {
-        "name": "LogFileName",
-        "description": "Overrides the default log file name. The default log file name is generated from the MSI file name. If LogFileName does not end in .log, it will be automatically appended. For uninstallations, by default the product code is resolved to the DisplayName and version of the application."
-      },
-      {
-        "name": "RepairMode",
-        "description": "Specifies the mode of repair. Choosing `Repair` will repair via `msiexec.exe /p` (which can trigger unsupressable reboots). Choosing `Reinstall` will reinstall by adding `REINSTALL=ALL REINSTALLMODE=omus` to the standard InstallParams."
-      },
-      {
-        "name": "RepairFromSource",
-        "description": "Specifies whether we should repair from source. Also rewrites local cache."
-      },
-      {
-        "name": "SkipMSIAlreadyInstalledCheck",
-        "description": "Skips the check to determine if the MSI is already installed on the system."
-      },
-      {
-        "name": "IncludeUpdatesAndHotfixes",
-        "description": "Include matches against updates and hotfixes in results."
-      },
-      {
-        "name": "SuccessExitCodes",
-        "description": "List of exit codes to be considered successful. Defaults to values set during ADTSession initialization, otherwise: 0"
-      },
-      {
-        "name": "RebootExitCodes",
-        "description": "List of exit codes to indicate a reboot is required. Defaults to values set during ADTSession initialization, otherwise: 1641, 3010"
-      },
-      {
-        "name": "IgnoreExitCodes",
-        "description": "List the exit codes to ignore or * to ignore all exit codes."
-      },
-      {
-        "name": "PriorityClass",
-        "description": "Specifies priority class for the process. Options: Idle, Normal, High, AboveNormal, BelowNormal, RealTime."
+        "name": "ArgumentList",
+        "description": "Overrides the default parameters specified in the config.psd1 file.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "/QN",
+        "placeholderQuote": "'"
       },
       {
         "name": "ExitOnProcessFailure",
-        "description": "Automatically closes the active deployment session via Close-ADTSession in the event the process exits with a non-success or non-ignored exit code."
+        "description": "Automatically closes the active deployment session via Close-ADTSession in the event the process exits with a non-success or non-ignored exit code.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "ExpandEnvironmentVariables",
+        "description": "Specifies whether to expand any Windows/DOS-style environment variables in the specified FilePath/ArgumentList.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "FilePath",
+        "description": "The file path to the MSI/MSP file.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "Adobe_FlashPlayer_11.2.202.233_x64_EN.msi",
+        "placeholderQuote": "'"
+      },
+      {
+        "name": "IgnoreExitCodes",
+        "description": "List the exit codes to ignore or * to ignore all exit codes.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "IncludeUpdatesAndHotfixes",
+        "description": "Include matches against updates and hotfixes in results.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "InheritEnvironmentVariables",
+        "description": "Specifies whether the process running as a user should inherit the SYSTEM account's environment variables.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "InstalledApplication",
+        "description": "The InstalledApplication object of the installed MSI.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "LogFileName",
+        "description": "Overrides the default log file name. The default log file name is generated from the MSI file name. If LogFileName does not end in .log, it will be automatically appended. For uninstallations, by default the product code is resolved to the DisplayName and version of the application.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "LoggingOptions",
+        "description": "Overrides the default logging options specified in the config.psd1 file.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "NoDesktopRefresh",
-        "description": "If specifies, doesn't refresh the desktop and environment after successful MSI installation."
+        "description": "If specifies, doesn't refresh the desktop and environment after successful MSI installation.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "NoWait",
-        "description": "Immediately continue after executing the process."
+        "description": "Immediately continue after executing the process.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "PassThru",
-        "description": "Returns ExitCode, StdOut, and StdErr output from the process. Note that a failed execution will only return an object if either `-ErrorAction` is set to `SilentlyContinue`/`Ignore`, or if `-IgnoreExitCodes`/`-SuccessExitCodes` are used."
+        "description": "Returns ExitCode, StdOut, and StdErr output from the process. Note that a failed execution will only return an object if either `-ErrorAction` is set to `SilentlyContinue`/`Ignore`, or if `-IgnoreExitCodes`/`-SuccessExitCodes` are used.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "Patches",
+        "description": "The name(s) of the patch (MSP) file(s) to be applied to the MSI for the \"Install\" action. The patch files should be in the same directory as the MSI file.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "PriorityClass",
+        "description": "Specifies priority class for the process. Options: Idle, Normal, High, AboveNormal, BelowNormal, RealTime.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "ProductCode",
+        "description": "The product code of the installed MSI.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "{26923b43-4d38-484f-9b9e-de460746276c}",
+        "placeholderQuote": "'"
+      },
+      {
+        "name": "RebootExitCodes",
+        "description": "List of exit codes to indicate a reboot is required. Defaults to values set during ADTSession initialization, otherwise: 1641, 3010",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "RepairFromSource",
+        "description": "Specifies whether we should repair from source. Also rewrites local cache.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "RepairMode",
+        "description": "Specifies the mode of repair. Choosing `Repair` will repair via `msiexec.exe /p` (which can trigger unsupressable reboots). Choosing `Reinstall` will reinstall by adding `REINSTALL=ALL REINSTALLMODE=omus` to the standard InstallParams.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "RunAsActiveUser",
+        "description": "A RunAsActiveUser object to invoke the process as.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "SecureArgumentList",
+        "description": "Hides all parameters passed to the MSI or MSP file from the toolkit log file.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "SkipMSIAlreadyInstalledCheck",
+        "description": "Skips the check to determine if the MSI is already installed on the system.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "SuccessExitCodes",
+        "description": "List of exit codes to be considered successful. Defaults to values set during ADTSession initialization, otherwise: 0",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "Transforms",
+        "description": "The name(s) of the transform file(s) to be applied to the MSI. The transform files should be in the same directory as the MSI file.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "Adobe_FlashPlayer_11.2.202.233_x64_EN_01.mst",
+        "placeholderQuote": "'"
+      },
+      {
+        "name": "UseHighestAvailableToken",
+        "description": "Use a user's linked administrative token if it's available while running the process under their context.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "UseLinkedAdminToken",
+        "description": "Use a user's linked administrative token while running the process under their context.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "UseUnelevatedToken",
+        "description": "If the current process is elevated, starts the new process unelevated using the user's unelevated linked token.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "WorkingDirectory",
+        "description": "Overrides the working directory. The working directory is set to the location of the MSI file.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       }
     ]
   },
@@ -2637,119 +6263,351 @@
     "parameters": [
       {
         "name": "Action",
-        "description": "Specifies the action to be performed. Available options: Install, Uninstall, Patch, Repair, ActiveSetup."
-      },
-      {
-        "name": "FilePath",
-        "description": "The file path to the MSI/MSP file."
-      },
-      {
-        "name": "ProductCode",
-        "description": "The product code of the installed MSI."
-      },
-      {
-        "name": "InstalledApplication",
-        "description": "The InstalledApplication object of the installed MSI."
-      },
-      {
-        "name": "ArgumentList",
-        "description": "Overrides the default parameters specified in the config.psd1 file."
+        "description": "Specifies the action to be performed. Available options: Install, Uninstall, Patch, Repair, ActiveSetup.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "Install",
+        "placeholderQuote": "'"
       },
       {
         "name": "AdditionalArgumentList",
-        "description": "Adds additional parameters to the default set specified in the config.psd1 file."
+        "description": "Adds additional parameters to the default set specified in the config.psd1 file.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
-        "name": "SecureArgumentList",
-        "description": "Hides all parameters passed to the MSI or MSP file from the toolkit log file."
-      },
-      {
-        "name": "WorkingDirectory",
-        "description": "Overrides the working directory. The working directory is set to the location of the MSI file."
-      },
-      {
-        "name": "Transforms",
-        "description": "The name(s) of the transform file(s) to be applied to the MSI. The transform files should be in the same directory as the MSI file."
-      },
-      {
-        "name": "Patches",
-        "description": "The name(s) of the patch (MSP) file(s) to be applied to the MSI for the \"Install\" action. The patch files should be in the same directory as the MSI file."
-      },
-      {
-        "name": "Username",
-        "description": "A username to invoke the process as. Only supported while running as the SYSTEM account."
-      },
-      {
-        "name": "UseLinkedAdminToken",
-        "description": "Use a user's linked administrative token while running the process under their context."
-      },
-      {
-        "name": "UseHighestAvailableToken",
-        "description": "Use a user's linked administrative token if it's available while running the process under their context."
-      },
-      {
-        "name": "InheritEnvironmentVariables",
-        "description": "Specifies whether the process running as a user should inherit the SYSTEM account's environment variables."
-      },
-      {
-        "name": "ExpandEnvironmentVariables",
-        "description": "Specifies whether to expand any Windows/DOS-style environment variables in the specified FilePath/ArgumentList."
-      },
-      {
-        "name": "LoggingOptions",
-        "description": "Overrides the default logging options specified in the config.psd1 file."
-      },
-      {
-        "name": "LogFileName",
-        "description": "Overrides the default log file name. The default log file name is generated from the MSI file name. If LogFileName does not end in .log, it will be automatically appended. For uninstallations, by default the product code is resolved to the DisplayName and version of the application."
-      },
-      {
-        "name": "RepairMode",
-        "description": "Specifies the mode of repair. Choosing `Repair` will repair via `msiexec.exe /p` (which can trigger unsupressable reboots). Choosing `Reinstall` will reinstall by adding `REINSTALL=ALL REINSTALLMODE=omus` to the standard InstallParams."
-      },
-      {
-        "name": "RepairFromSource",
-        "description": "Specifies whether we should repair from source. Also rewrites local cache."
-      },
-      {
-        "name": "SkipMSIAlreadyInstalledCheck",
-        "description": "Skips the check to determine if the MSI is already installed on the system."
-      },
-      {
-        "name": "IncludeUpdatesAndHotfixes",
-        "description": "Include matches against updates and hotfixes in results."
-      },
-      {
-        "name": "SuccessExitCodes",
-        "description": "List of exit codes to be considered successful. Defaults to values set during ADTSession initialization, otherwise: 0"
-      },
-      {
-        "name": "RebootExitCodes",
-        "description": "List of exit codes to indicate a reboot is required. Defaults to values set during ADTSession initialization, otherwise: 1641, 3010"
-      },
-      {
-        "name": "IgnoreExitCodes",
-        "description": "List the exit codes to ignore or * to ignore all exit codes."
-      },
-      {
-        "name": "PriorityClass",
-        "description": "Specifies priority class for the process. Options: Idle, Normal, High, AboveNormal, BelowNormal, RealTime."
+        "name": "ArgumentList",
+        "description": "Overrides the default parameters specified in the config.psd1 file.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "/QN",
+        "placeholderQuote": "'"
       },
       {
         "name": "ExitOnProcessFailure",
-        "description": "Automatically closes the active deployment session via Close-ADTSession in the event the process exits with a non-success or non-ignored exit code."
+        "description": "Automatically closes the active deployment session via Close-ADTSession in the event the process exits with a non-success or non-ignored exit code.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "ExpandEnvironmentVariables",
+        "description": "Specifies whether to expand any Windows/DOS-style environment variables in the specified FilePath/ArgumentList.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "FilePath",
+        "description": "The file path to the MSI/MSP file.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "Adobe_FlashPlayer_11.2.202.233_x64_EN.msi",
+        "placeholderQuote": "'"
+      },
+      {
+        "name": "IgnoreExitCodes",
+        "description": "List the exit codes to ignore or * to ignore all exit codes.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "IncludeUpdatesAndHotfixes",
+        "description": "Include matches against updates and hotfixes in results.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "InheritEnvironmentVariables",
+        "description": "Specifies whether the process running as a user should inherit the SYSTEM account's environment variables.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "InstalledApplication",
+        "description": "The InstalledApplication object of the installed MSI.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "LogFileName",
+        "description": "Overrides the default log file name. The default log file name is generated from the MSI file name. If LogFileName does not end in .log, it will be automatically appended. For uninstallations, by default the product code is resolved to the DisplayName and version of the application.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "LoggingOptions",
+        "description": "Overrides the default logging options specified in the config.psd1 file.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "NoDesktopRefresh",
-        "description": "If specifies, doesn't refresh the desktop and environment after successful MSI installation."
+        "description": "If specifies, doesn't refresh the desktop and environment after successful MSI installation.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "NoWait",
-        "description": "Immediately continue after executing the process."
+        "description": "Immediately continue after executing the process.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "PassThru",
-        "description": "Returns ExitCode, StdOut, and StdErr output from the process. Note that a failed execution will only return an object if either `-ErrorAction` is set to `SilentlyContinue`/`Ignore`, or if `-IgnoreExitCodes`/`-SuccessExitCodes` are used."
+        "description": "Returns ExitCode, StdOut, and StdErr output from the process. Note that a failed execution will only return an object if either `-ErrorAction` is set to `SilentlyContinue`/`Ignore`, or if `-IgnoreExitCodes`/`-SuccessExitCodes` are used.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "Patches",
+        "description": "The name(s) of the patch (MSP) file(s) to be applied to the MSI for the \"Install\" action. The patch files should be in the same directory as the MSI file.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "PriorityClass",
+        "description": "Specifies priority class for the process. Options: Idle, Normal, High, AboveNormal, BelowNormal, RealTime.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "ProductCode",
+        "description": "The product code of the installed MSI.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "{26923b43-4d38-484f-9b9e-de460746276c}",
+        "placeholderQuote": "'"
+      },
+      {
+        "name": "RebootExitCodes",
+        "description": "List of exit codes to indicate a reboot is required. Defaults to values set during ADTSession initialization, otherwise: 1641, 3010",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "RepairFromSource",
+        "description": "Specifies whether we should repair from source. Also rewrites local cache.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "RepairMode",
+        "description": "Specifies the mode of repair. Choosing `Repair` will repair via `msiexec.exe /p` (which can trigger unsupressable reboots). Choosing `Reinstall` will reinstall by adding `REINSTALL=ALL REINSTALLMODE=omus` to the standard InstallParams.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "SecureArgumentList",
+        "description": "Hides all parameters passed to the MSI or MSP file from the toolkit log file.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "SkipMSIAlreadyInstalledCheck",
+        "description": "Skips the check to determine if the MSI is already installed on the system.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "SuccessExitCodes",
+        "description": "List of exit codes to be considered successful. Defaults to values set during ADTSession initialization, otherwise: 0",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "Transforms",
+        "description": "The name(s) of the transform file(s) to be applied to the MSI. The transform files should be in the same directory as the MSI file.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "Adobe_FlashPlayer_11.2.202.233_x64_EN_01.mst",
+        "placeholderQuote": "'"
+      },
+      {
+        "name": "UseHighestAvailableToken",
+        "description": "Use a user's linked administrative token if it's available while running the process under their context.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "UseLinkedAdminToken",
+        "description": "Use a user's linked administrative token while running the process under their context.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "Username",
+        "description": "A username to invoke the process as. Only supported while running as the SYSTEM account.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "WorkingDirectory",
+        "description": "Overrides the working directory. The working directory is set to the location of the MSI file.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       }
     ]
   },
@@ -2760,36 +6618,100 @@
     "link": "https://psappdeploytoolkit.com/docs/reference/functions/Start-ADTMspProcess",
     "parameters": [
       {
-        "name": "FilePath",
-        "description": "Path to the MSP file."
-      },
-      {
         "name": "AdditionalArgumentList",
-        "description": "Additional parameters."
-      },
-      {
-        "name": "RunAsActiveUser",
-        "description": "A RunAsActiveUser object to invoke the process as."
-      },
-      {
-        "name": "UseLinkedAdminToken",
-        "description": "Use a user's linked administrative token while running the process under their context."
-      },
-      {
-        "name": "UseHighestAvailableToken",
-        "description": "Use a user's linked administrative token if it's available while running the process under their context."
-      },
-      {
-        "name": "InheritEnvironmentVariables",
-        "description": "Specifies whether the process running as a user should inherit the SYSTEM account's environment variables."
-      },
-      {
-        "name": "UseUnelevatedToken",
-        "description": "If the current process is elevated, starts the new process unelevated using the user's unelevated linked token."
+        "description": "Additional parameters.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "ALLUSERS=1",
+        "placeholderQuote": "'"
       },
       {
         "name": "ExpandEnvironmentVariables",
-        "description": "Specifies whether to expand any Windows/DOS-style environment variables in the specified FilePath/ArgumentList."
+        "description": "Specifies whether to expand any Windows/DOS-style environment variables in the specified FilePath/ArgumentList.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "FilePath",
+        "description": "Path to the MSP file.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "Adobe_Reader_11.0.3_EN.msp",
+        "placeholderQuote": "'"
+      },
+      {
+        "name": "InheritEnvironmentVariables",
+        "description": "Specifies whether the process running as a user should inherit the SYSTEM account's environment variables.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "RunAsActiveUser",
+        "description": "A RunAsActiveUser object to invoke the process as.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "UseHighestAvailableToken",
+        "description": "Use a user's linked administrative token if it's available while running the process under their context.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "UseLinkedAdminToken",
+        "description": "Use a user's linked administrative token while running the process under their context.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "UseUnelevatedToken",
+        "description": "If the current process is elevated, starts the new process unelevated using the user's unelevated linked token.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       }
     ]
   },
@@ -2800,32 +6722,88 @@
     "link": "https://psappdeploytoolkit.com/docs/reference/functions/Start-ADTMspProcessAsUser",
     "parameters": [
       {
-        "name": "FilePath",
-        "description": "Path to the MSP file."
-      },
-      {
         "name": "AdditionalArgumentList",
-        "description": "Additional parameters."
-      },
-      {
-        "name": "Username",
-        "description": "A username to invoke the process as. Only supported while running as the SYSTEM account."
-      },
-      {
-        "name": "UseLinkedAdminToken",
-        "description": "Use a user's linked administrative token while running the process under their context."
-      },
-      {
-        "name": "UseHighestAvailableToken",
-        "description": "Use a user's linked administrative token if it's available while running the process under their context."
-      },
-      {
-        "name": "InheritEnvironmentVariables",
-        "description": "Specifies whether the process running as a user should inherit the SYSTEM account's environment variables."
+        "description": "Additional parameters.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "ALLUSERS=1",
+        "placeholderQuote": "'"
       },
       {
         "name": "ExpandEnvironmentVariables",
-        "description": "Specifies whether to expand any Windows/DOS-style environment variables in the specified FilePath/ArgumentList."
+        "description": "Specifies whether to expand any Windows/DOS-style environment variables in the specified FilePath/ArgumentList.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "FilePath",
+        "description": "Path to the MSP file.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "Adobe_Reader_11.0.3_EN.msp",
+        "placeholderQuote": "'"
+      },
+      {
+        "name": "InheritEnvironmentVariables",
+        "description": "Specifies whether the process running as a user should inherit the SYSTEM account's environment variables.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "UseHighestAvailableToken",
+        "description": "Use a user's linked administrative token if it's available while running the process under their context.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "UseLinkedAdminToken",
+        "description": "Use a user's linked administrative token while running the process under their context.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "Username",
+        "description": "A username to invoke the process as. Only supported while running as the SYSTEM account.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       }
     ]
   },
@@ -2836,124 +6814,364 @@
     "link": "https://psappdeploytoolkit.com/docs/reference/functions/Start-ADTProcess",
     "parameters": [
       {
-        "name": "FilePath",
-        "description": "Path to the file to be executed. If the file is located directly in the \"Files\" directory of the App Deploy Toolkit, only the file name needs to be specified. Otherwise, the full path of the file must be specified. If the files is in a subdirectory of \"Files\", use the \"$($adtSession.DirFiles)\" variable as shown in the example."
-      },
-      {
         "name": "ArgumentList",
-        "description": "Arguments to be passed to the executable."
-      },
-      {
-        "name": "SecureArgumentList",
-        "description": "Hides all parameters passed to the executable from the Toolkit log file."
-      },
-      {
-        "name": "WorkingDirectory",
-        "description": "The working directory used for executing the process. Defaults to DirFiles if there is an active DeploymentSession. The use of UseShellExecute affects this parameter."
-      },
-      {
-        "name": "RunAsActiveUser",
-        "description": "A RunAsActiveUser object to invoke the process as."
-      },
-      {
-        "name": "UseLinkedAdminToken",
-        "description": "Use a user's linked administrative token while running the process under their context."
-      },
-      {
-        "name": "UseHighestAvailableToken",
-        "description": "Use a user's linked administrative token if it's available while running the process under their context."
-      },
-      {
-        "name": "InheritEnvironmentVariables",
-        "description": "Specifies whether the process running as a user should inherit the SYSTEM account's environment variables."
-      },
-      {
-        "name": "UseUnelevatedToken",
-        "description": "If the current process is elevated, starts the new process unelevated using the user's unelevated linked token."
-      },
-      {
-        "name": "UseShellExecute",
-        "description": "Specifies whether to use the operating system shell to start the process. $true if the shell should be used when starting the process; $false if the process should be created directly from the executable file. The word \"Shell\" in this context refers to a graphical shell (similar to the Windows shell) rather than command shells (for example, bash or sh) and lets users launch graphical applications or open documents. It lets you open a file or a url and the Shell will figure out the program to open it with. The WorkingDirectory property behaves differently depending on the value of the UseShellExecute property. When UseShellExecute is true, the WorkingDirectory property specifies the location of the executable. When UseShellExecute is false, the WorkingDirectory property is not used to find the executable. Instead, it is used only by the process that is started and has meaning only within the context of the new process. If you set UseShellExecute to $true, there will be no available output from the process."
-      },
-      {
-        "name": "Verb",
-        "description": "The verb to use when doing a ShellExecute invocation. Common usages are \"runas\" to trigger a UAC elevation of the process."
-      },
-      {
-        "name": "ExpandEnvironmentVariables",
-        "description": "Specifies whether to expand any Windows/DOS-style environment variables in the specified FilePath/ArgumentList."
-      },
-      {
-        "name": "WindowStyle",
-        "description": "Style of the window of the process executed. Options: Normal, Hidden, Maximized, Minimized. Only works for native Windows GUI applications. If the WindowStyle is set to Hidden, UseShellExecute should be set to $true. Note: Not all processes honor WindowStyle. WindowStyle is a recommendation passed to the process. They can choose to ignore it."
+        "description": "Arguments to be passed to the executable.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "/S",
+        "placeholderQuote": "'"
       },
       {
         "name": "CreateNoWindow",
-        "description": "Specifies whether the process should be started with a new window to contain it."
-      },
-      {
-        "name": "StreamEncoding",
-        "description": "Specifies the encoding type to use when reading stdout/stderr. Some apps like WinGet encode using UTF8, which will corrupt if incorrectly set."
-      },
-      {
-        "name": "NoStreamLogging",
-        "description": "Don't log any available stdout/stderr data to the log file."
-      },
-      {
-        "name": "WaitForMsiExec",
-        "description": "Sometimes an EXE bootstrapper will launch an MSI install. In such cases, this variable will ensure that this function waits for the msiexec engine to become available before starting the install."
-      },
-      {
-        "name": "MsiExecWaitTime",
-        "description": "Specify the length of time in seconds to wait for the msiexec engine to become available."
-      },
-      {
-        "name": "WaitForChildProcesses",
-        "description": "Specifies whether the started process should be considered finished only when any child processes it spawns have finished also."
-      },
-      {
-        "name": "KillChildProcessesWithParent",
-        "description": "Specifies whether any child processes started by the provided executable should be closed when the provided executable closes. This is handy for application installs that open web browsers and other programs that cannot be suppressed."
-      },
-      {
-        "name": "Timeout",
-        "description": "How long to wait for the process before timing out."
-      },
-      {
-        "name": "TimeoutAction",
-        "description": "What action to take on timeout. Follows ErrorAction if not specified."
-      },
-      {
-        "name": "NoTerminateOnTimeout",
-        "description": "Indicates that the process should not be terminated on timeout. Only supported for GUI-based applications."
-      },
-      {
-        "name": "SuccessExitCodes",
-        "description": "List of exit codes to be considered successful. Defaults to values set during ADTSession initialization, otherwise: 0"
-      },
-      {
-        "name": "RebootExitCodes",
-        "description": "List of exit codes to indicate a reboot is required. Defaults to values set during ADTSession initialization, otherwise: 1641, 3010"
-      },
-      {
-        "name": "IgnoreExitCodes",
-        "description": "List the exit codes to ignore or * to ignore all exit codes. Where possible, please use `-SuccessExitCodes` and/or `-RebootExitCodes` instead."
-      },
-      {
-        "name": "PriorityClass",
-        "description": "Specifies priority class for the process. Options: Idle, Normal, High, AboveNormal, BelowNormal, RealTime."
+        "description": "Specifies whether the process should be started with a new window to contain it.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "ExitOnProcessFailure",
-        "description": "Automatically closes the active deployment session via Close-ADTSession in the event the process exits with a non-success or non-ignored exit code."
+        "description": "Automatically closes the active deployment session via Close-ADTSession in the event the process exits with a non-success or non-ignored exit code.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "ExpandEnvironmentVariables",
+        "description": "Specifies whether to expand any Windows/DOS-style environment variables in the specified FilePath/ArgumentList.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "FilePath",
+        "description": "Path to the file to be executed. If the file is located directly in the \"Files\" directory of the App Deploy Toolkit, only the file name needs to be specified. Otherwise, the full path of the file must be specified. If the files is in a subdirectory of \"Files\", use the \"$($adtSession.DirFiles)\" variable as shown in the example.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "setup.exe",
+        "placeholderQuote": "'"
+      },
+      {
+        "name": "IgnoreExitCodes",
+        "description": "List the exit codes to ignore or * to ignore all exit codes. Where possible, please use `-SuccessExitCodes` and/or `-RebootExitCodes` instead.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "InheritEnvironmentVariables",
+        "description": "Specifies whether the process running as a user should inherit the SYSTEM account's environment variables.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "KillChildProcessesWithParent",
+        "description": "Specifies whether any child processes started by the provided executable should be closed when the provided executable closes. This is handy for application installs that open web browsers and other programs that cannot be suppressed.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "MsiExecWaitTime",
+        "description": "Specify the length of time in seconds to wait for the msiexec engine to become available.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "NoStreamLogging",
+        "description": "Don't log any available stdout/stderr data to the log file.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "NoTerminateOnTimeout",
+        "description": "Indicates that the process should not be terminated on timeout. Only supported for GUI-based applications.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "NoWait",
-        "description": "Immediately continue after executing the process."
+        "description": "Immediately continue after executing the process.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "PassThru",
-        "description": "If `-NoWait` is not specified, returns an object with ExitCode, StdOut, and StdErr output from the process. If `-NoWait` is specified, returns a task that can be awaited. Note that a failed execution will only return an object if either `-ErrorAction` is set to `SilentlyContinue`/`Ignore`, or if `-IgnoreExitCodes`/`-SuccessExitCodes` are used."
+        "description": "If `-NoWait` is not specified, returns an object with ExitCode, StdOut, and StdErr output from the process. If `-NoWait` is specified, returns a task that can be awaited. Note that a failed execution will only return an object if either `-ErrorAction` is set to `SilentlyContinue`/`Ignore`, or if `-IgnoreExitCodes`/`-SuccessExitCodes` are used.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "PriorityClass",
+        "description": "Specifies priority class for the process. Options: Idle, Normal, High, AboveNormal, BelowNormal, RealTime.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "RebootExitCodes",
+        "description": "List of exit codes to indicate a reboot is required. Defaults to values set during ADTSession initialization, otherwise: 1641, 3010",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "RunAsActiveUser",
+        "description": "A RunAsActiveUser object to invoke the process as.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "SecureArgumentList",
+        "description": "Hides all parameters passed to the executable from the Toolkit log file.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "StreamEncoding",
+        "description": "Specifies the encoding type to use when reading stdout/stderr. Some apps like WinGet encode using UTF8, which will corrupt if incorrectly set.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "SuccessExitCodes",
+        "description": "List of exit codes to be considered successful. Defaults to values set during ADTSession initialization, otherwise: 0",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "1,2",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "Timeout",
+        "description": "How long to wait for the process before timing out.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "TimeoutAction",
+        "description": "What action to take on timeout. Follows ErrorAction if not specified.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "UseHighestAvailableToken",
+        "description": "Use a user's linked administrative token if it's available while running the process under their context.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "UseLinkedAdminToken",
+        "description": "Use a user's linked administrative token while running the process under their context.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "UseShellExecute",
+        "description": "Specifies whether to use the operating system shell to start the process. $true if the shell should be used when starting the process; $false if the process should be created directly from the executable file. The word \"Shell\" in this context refers to a graphical shell (similar to the Windows shell) rather than command shells (for example, bash or sh) and lets users launch graphical applications or open documents. It lets you open a file or a url and the Shell will figure out the program to open it with. The WorkingDirectory property behaves differently depending on the value of the UseShellExecute property. When UseShellExecute is true, the WorkingDirectory property specifies the location of the executable. When UseShellExecute is false, the WorkingDirectory property is not used to find the executable. Instead, it is used only by the process that is started and has meaning only within the context of the new process. If you set UseShellExecute to $true, there will be no available output from the process.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "UseUnelevatedToken",
+        "description": "If the current process is elevated, starts the new process unelevated using the user's unelevated linked token.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "Verb",
+        "description": "The verb to use when doing a ShellExecute invocation. Common usages are \"runas\" to trigger a UAC elevation of the process.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "WaitForChildProcesses",
+        "description": "Specifies whether the started process should be considered finished only when any child processes it spawns have finished also.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "WaitForMsiExec",
+        "description": "Sometimes an EXE bootstrapper will launch an MSI install. In such cases, this variable will ensure that this function waits for the msiexec engine to become available before starting the install.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "WindowStyle",
+        "description": "Style of the window of the process executed. Options: Normal, Hidden, Maximized, Minimized. Only works for native Windows GUI applications. If the WindowStyle is set to Hidden, UseShellExecute should be set to $true. Note: Not all processes honor WindowStyle. WindowStyle is a recommendation passed to the process. They can choose to ignore it.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "Hidden",
+        "placeholderQuote": "'"
+      },
+      {
+        "name": "WorkingDirectory",
+        "description": "The working directory used for executing the process. Defaults to DirFiles if there is an active DeploymentSession. The use of UseShellExecute affects this parameter.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       }
     ]
   },
@@ -2964,112 +7182,328 @@
     "link": "https://psappdeploytoolkit.com/docs/reference/functions/Start-ADTProcess",
     "parameters": [
       {
-        "name": "FilePath",
-        "description": "Path to the file to be executed. If the file is located directly in the \"Files\" directory of the App Deploy Toolkit, only the file name needs to be specified. Otherwise, the full path of the file must be specified. If the files is in a subdirectory of \"Files\", use the \"$($adtSession.DirFiles)\" variable as shown in the example."
-      },
-      {
         "name": "ArgumentList",
-        "description": "Arguments to be passed to the executable."
-      },
-      {
-        "name": "SecureArgumentList",
-        "description": "Hides all parameters passed to the executable from the Toolkit log file."
-      },
-      {
-        "name": "WorkingDirectory",
-        "description": "The working directory used for executing the process. Defaults to the directory of the file being executed. The use of UseShellExecute affects this parameter."
-      },
-      {
-        "name": "Username",
-        "description": "A username to invoke the process as. Only supported while running as the SYSTEM account."
-      },
-      {
-        "name": "UseLinkedAdminToken",
-        "description": "Use a user's linked administrative token while running the process under their context."
-      },
-      {
-        "name": "UseHighestAvailableToken",
-        "description": "Use a user's linked administrative token if it's available while running the process under their context."
-      },
-      {
-        "name": "InheritEnvironmentVariables",
-        "description": "Specifies whether the process running as a user should inherit the SYSTEM account's environment variables."
-      },
-      {
-        "name": "ExpandEnvironmentVariables",
-        "description": "Specifies whether to expand any Windows/DOS-style environment variables in the specified FilePath/ArgumentList."
-      },
-      {
-        "name": "WindowStyle",
-        "description": "Style of the window of the process executed. Options: Normal, Hidden, Maximized, Minimized. Only works for native Windows GUI applications. If the WindowStyle is set to Hidden, UseShellExecute should be set to $true. Note: Not all processes honor WindowStyle. WindowStyle is a recommendation passed to the process. They can choose to ignore it."
+        "description": "Arguments to be passed to the executable.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "/S",
+        "placeholderQuote": "'"
       },
       {
         "name": "CreateNoWindow",
-        "description": "Specifies whether the process should be started with a new window to contain it."
-      },
-      {
-        "name": "StreamEncoding",
-        "description": "Specifies the encoding type to use when reading stdout/stderr. Some apps like WinGet encode using UTF8, which will corrupt if incorrectly set."
-      },
-      {
-        "name": "NoStreamLogging",
-        "description": "Don't log any available stdout/stderr data to the log file."
-      },
-      {
-        "name": "WaitForMsiExec",
-        "description": "Sometimes an EXE bootstrapper will launch an MSI install. In such cases, this variable will ensure that this function waits for the msiexec engine to become available before starting the install."
-      },
-      {
-        "name": "MsiExecWaitTime",
-        "description": "Specify the length of time in seconds to wait for the msiexec engine to become available."
-      },
-      {
-        "name": "WaitForChildProcesses",
-        "description": "Specifies whether the started process should be considered finished only when any child processes it spawns have finished also."
-      },
-      {
-        "name": "KillChildProcessesWithParent",
-        "description": "Specifies whether any child processes started by the provided executable should be closed when the provided executable closes. This is handy for application installs that open web browsers and other programs that cannot be suppressed."
-      },
-      {
-        "name": "Timeout",
-        "description": "How long to wait for the process before timing out."
-      },
-      {
-        "name": "TimeoutAction",
-        "description": "What action to take on timeout. Follows ErrorAction if not specified."
-      },
-      {
-        "name": "NoTerminateOnTimeout",
-        "description": "Indicates that the process should not be terminated on timeout. Only supported for GUI-based applications, or when -CreateNoWindow isn't specified."
-      },
-      {
-        "name": "SuccessExitCodes",
-        "description": "List of exit codes to be considered successful. Defaults to values set during ADTSession initialization, otherwise: 0"
-      },
-      {
-        "name": "RebootExitCodes",
-        "description": "List of exit codes to indicate a reboot is required. Defaults to values set during ADTSession initialization, otherwise: 1641, 3010"
-      },
-      {
-        "name": "IgnoreExitCodes",
-        "description": "List the exit codes to ignore or * to ignore all exit codes."
-      },
-      {
-        "name": "PriorityClass",
-        "description": "Specifies priority class for the process. Options: Idle, Normal, High, AboveNormal, BelowNormal, RealTime."
+        "description": "Specifies whether the process should be started with a new window to contain it.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "ExitOnProcessFailure",
-        "description": "Automatically closes the active deployment session via Close-ADTSession in the event the process exits with a non-success or non-ignored exit code."
+        "description": "Automatically closes the active deployment session via Close-ADTSession in the event the process exits with a non-success or non-ignored exit code.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "ExpandEnvironmentVariables",
+        "description": "Specifies whether to expand any Windows/DOS-style environment variables in the specified FilePath/ArgumentList.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "FilePath",
+        "description": "Path to the file to be executed. If the file is located directly in the \"Files\" directory of the App Deploy Toolkit, only the file name needs to be specified. Otherwise, the full path of the file must be specified. If the files is in a subdirectory of \"Files\", use the \"$($adtSession.DirFiles)\" variable as shown in the example.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "setup.exe",
+        "placeholderQuote": "'"
+      },
+      {
+        "name": "IgnoreExitCodes",
+        "description": "List the exit codes to ignore or * to ignore all exit codes.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "1,2",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "InheritEnvironmentVariables",
+        "description": "Specifies whether the process running as a user should inherit the SYSTEM account's environment variables.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "KillChildProcessesWithParent",
+        "description": "Specifies whether any child processes started by the provided executable should be closed when the provided executable closes. This is handy for application installs that open web browsers and other programs that cannot be suppressed.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "MsiExecWaitTime",
+        "description": "Specify the length of time in seconds to wait for the msiexec engine to become available.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "NoStreamLogging",
+        "description": "Don't log any available stdout/stderr data to the log file.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "NoTerminateOnTimeout",
+        "description": "Indicates that the process should not be terminated on timeout. Only supported for GUI-based applications, or when -CreateNoWindow isn't specified.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "NoWait",
-        "description": "Immediately continue after executing the process."
+        "description": "Immediately continue after executing the process.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "PassThru",
-        "description": "If `-NoWait` is not specified, returns an object with ExitCode, StdOut, and StdErr output from the process. If `-NoWait` is specified, returns a task that can be awaited. Note that a failed execution will only return an object if either `-ErrorAction` is set to `SilentlyContinue`/`Ignore`, or if `-IgnoreExitCodes`/`-SuccessExitCodes` are used."
+        "description": "If `-NoWait` is not specified, returns an object with ExitCode, StdOut, and StdErr output from the process. If `-NoWait` is specified, returns a task that can be awaited. Note that a failed execution will only return an object if either `-ErrorAction` is set to `SilentlyContinue`/`Ignore`, or if `-IgnoreExitCodes`/`-SuccessExitCodes` are used.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "PriorityClass",
+        "description": "Specifies priority class for the process. Options: Idle, Normal, High, AboveNormal, BelowNormal, RealTime.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "RebootExitCodes",
+        "description": "List of exit codes to indicate a reboot is required. Defaults to values set during ADTSession initialization, otherwise: 1641, 3010",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "SecureArgumentList",
+        "description": "Hides all parameters passed to the executable from the Toolkit log file.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "StreamEncoding",
+        "description": "Specifies the encoding type to use when reading stdout/stderr. Some apps like WinGet encode using UTF8, which will corrupt if incorrectly set.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "SuccessExitCodes",
+        "description": "List of exit codes to be considered successful. Defaults to values set during ADTSession initialization, otherwise: 0",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "Timeout",
+        "description": "How long to wait for the process before timing out.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "TimeoutAction",
+        "description": "What action to take on timeout. Follows ErrorAction if not specified.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "UseHighestAvailableToken",
+        "description": "Use a user's linked administrative token if it's available while running the process under their context.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "UseLinkedAdminToken",
+        "description": "Use a user's linked administrative token while running the process under their context.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "Username",
+        "description": "A username to invoke the process as. Only supported while running as the SYSTEM account.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "WaitForChildProcesses",
+        "description": "Specifies whether the started process should be considered finished only when any child processes it spawns have finished also.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "WaitForMsiExec",
+        "description": "Sometimes an EXE bootstrapper will launch an MSI install. In such cases, this variable will ensure that this function waits for the msiexec engine to become available before starting the install.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "WindowStyle",
+        "description": "Style of the window of the process executed. Options: Normal, Hidden, Maximized, Minimized. Only works for native Windows GUI applications. If the WindowStyle is set to Hidden, UseShellExecute should be set to $true. Note: Not all processes honor WindowStyle. WindowStyle is a recommendation passed to the process. They can choose to ignore it.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "Hidden",
+        "placeholderQuote": "'"
+      },
+      {
+        "name": "WorkingDirectory",
+        "description": "The working directory used for executing the process. Defaults to the directory of the file being executed. The use of UseShellExecute affects this parameter.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       }
     ]
   },
@@ -3080,24 +7514,64 @@
     "link": "https://psappdeploytoolkit.com/docs/reference/functions/Start-ADTServiceAndDependencies",
     "parameters": [
       {
-        "name": "Name",
-        "description": "Specify the name of the service."
-      },
-      {
         "name": "InputObject",
-        "description": "A ServiceController object to start."
+        "description": "A ServiceController object to start.",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.ServiceProcess.ServiceController",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
-        "name": "SkipDependentServices",
-        "description": "Choose to skip checking for and starting dependent services."
-      },
-      {
-        "name": "PendingStatusWait",
-        "description": "The amount of time to wait for a service to get out of a pending state before continuing. Default is 60 seconds."
+        "name": "Name",
+        "description": "Specify the name of the service.",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "wuauserv",
+        "placeholderQuote": "'"
       },
       {
         "name": "PassThru",
-        "description": "Return the System.ServiceProcess.ServiceController service object."
+        "description": "Return the System.ServiceProcess.ServiceController service object.",
+        "required": false,
+        "isSwitch": true,
+        "type": "System.Management.Automation.SwitchParameter",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "PendingStatusWait",
+        "description": "The amount of time to wait for a service to get out of a pending state before continuing. Default is 60 seconds.",
+        "required": false,
+        "isSwitch": false,
+        "type": "System.TimeSpan",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "SkipDependentServices",
+        "description": "Choose to skip checking for and starting dependent services.",
+        "required": false,
+        "isSwitch": true,
+        "type": "System.Management.Automation.SwitchParameter",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       }
     ]
   },
@@ -3108,24 +7582,64 @@
     "link": "https://psappdeploytoolkit.com/docs/reference/functions/Stop-ADTServiceAndDependencies",
     "parameters": [
       {
-        "name": "Name",
-        "description": "Specify the name of the service."
-      },
-      {
         "name": "InputObject",
-        "description": "A ServiceController object to stop."
+        "description": "A ServiceController object to stop.",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.ServiceProcess.ServiceController",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
-        "name": "SkipDependentServices",
-        "description": "Choose to skip checking for and stopping dependent services."
-      },
-      {
-        "name": "PendingStatusWait",
-        "description": "The amount of time to wait for a service to get out of a pending state before continuing. Default is 60 seconds."
+        "name": "Name",
+        "description": "Specify the name of the service.",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "wuauserv",
+        "placeholderQuote": "'"
       },
       {
         "name": "PassThru",
-        "description": "Return the System.ServiceProcess.ServiceController service object."
+        "description": "Return the System.ServiceProcess.ServiceController service object.",
+        "required": false,
+        "isSwitch": true,
+        "type": "System.Management.Automation.SwitchParameter",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "PendingStatusWait",
+        "description": "The amount of time to wait for a service to get out of a pending state before continuing. Default is 60 seconds.",
+        "required": false,
+        "isSwitch": false,
+        "type": "System.TimeSpan",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "SkipDependentServices",
+        "description": "Choose to skip checking for and stopping dependent services.",
+        "required": false,
+        "isSwitch": true,
+        "type": "System.Management.Automation.SwitchParameter",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       }
     ]
   },
@@ -3134,7 +7648,44 @@
     "synopsis": "",
     "description": "",
     "link": "",
-    "parameters": []
+    "parameters": [
+      {
+        "name": "HKCUKey",
+        "description": "",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "HKLMKey",
+        "description": "",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "SID",
+        "description": "",
+        "required": false,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      }
+    ]
   },
   {
     "name": "Test-ADTBattery",
@@ -3144,7 +7695,15 @@
     "parameters": [
       {
         "name": "PassThru",
-        "description": "Outputs an object containing the following properties: - ACPowerLineStatus - BatteryChargeStatus - BatteryLifePercent - BatterySaverEnabled - BatteryLifeRemaining - BatteryFullLifetime - IsUsingACPower - IsLaptop"
+        "description": "Outputs an object containing the following properties: - ACPowerLineStatus - BatteryChargeStatus - BatteryLifePercent - BatterySaverEnabled - BatteryLifeRemaining - BatteryFullLifetime - IsUsingACPower - IsLaptop",
+        "required": false,
+        "isSwitch": true,
+        "type": "System.Management.Automation.SwitchParameter",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       }
     ]
   },
@@ -3184,7 +7743,15 @@
     "parameters": [
       {
         "name": "KbNumber",
-        "description": "KBNumber of the update."
+        "description": "KBNumber of the update.",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "KB2549864",
+        "placeholderQuote": "'"
       }
     ]
   },
@@ -3196,11 +7763,27 @@
     "parameters": [
       {
         "name": "MutexName",
-        "description": "The name of the system mutex."
+        "description": "The name of the system mutex.",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "Global\\_MSIExecute",
+        "placeholderQuote": "'"
       },
       {
         "name": "MutexWaitTime",
-        "description": "The number of milliseconds the current thread should wait to acquire an exclusive lock of a named mutex. A wait time of -1 milliseconds means to wait indefinitely. A wait time of zero does not acquire an exclusive lock but instead tests the state of the wait handle and returns immediately."
+        "description": "The number of milliseconds the current thread should wait to acquire an exclusive lock of a named mutex. A wait time of -1 milliseconds means to wait indefinitely. A wait time of zero does not acquire an exclusive lock but instead tests the state of the wait handle and returns immediately.",
+        "required": false,
+        "isSwitch": false,
+        "type": "System.TimeSpan",
+        "defaultValue": "[System.TimeSpan]::FromMilliseconds(1)",
+        "defaultRaw": "[System.TimeSpan]::FromMilliseconds(1)",
+        "defaultQuote": "",
+        "placeholder": "5000000",
+        "placeholderQuote": ""
       }
     ]
   },
@@ -3233,19 +7816,51 @@
     "parameters": [
       {
         "name": "Key",
-        "description": "Path of the registry key."
+        "description": "Path of the registry key.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "HKLM:SYSTEM\\CurrentControlSet\\Control\\Session Manager",
+        "placeholderQuote": "'"
       },
       {
         "name": "Name",
-        "description": "Specify the name of the value to check the existence of."
+        "description": "Specify the name of the value to check the existence of.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "PendingFileRenameOperations",
+        "placeholderQuote": "'"
       },
       {
         "name": "SID",
-        "description": "The security identifier (SID) for a user. Specifying this parameter will convert a HKEY_CURRENT_USER registry key to the HKEY_USERS\\$SID format. Specify this parameter from the Invoke-ADTAllUsersRegistryAction function to read/edit HKCU registry settings for all users on the system."
+        "description": "The security identifier (SID) for a user. Specifying this parameter will convert a HKEY_CURRENT_USER registry key to the HKEY_USERS\\$SID format. Specify this parameter from the Invoke-ADTAllUsersRegistryAction function to read/edit HKCU registry settings for all users on the system.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "Wow6432Node",
-        "description": "Specify this switch to check the 32-bit registry (Wow6432Node) on 64-bit systems."
+        "description": "Specify this switch to check the 32-bit registry (Wow6432Node) on 64-bit systems.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       }
     ]
   },
@@ -3257,15 +7872,39 @@
     "parameters": [
       {
         "name": "Name",
-        "description": "Specify the name of the service. Note: Service name can be found by executing \"Get-Service | Format-Table -AutoSize -Wrap\" or by using the properties screen of a service in services.msc."
-      },
-      {
-        "name": "UseCIM",
-        "description": "Use CIM/WMI to check for the service. This is useful for compatibility with PSADT v3.x."
+        "description": "Specify the name of the service. Note: Service name can be found by executing \"Get-Service | Format-Table -AutoSize -Wrap\" or by using the properties screen of a service in services.msc.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "wuauserv",
+        "placeholderQuote": "'"
       },
       {
         "name": "PassThru",
-        "description": "Return the WMI service object. To see all the properties use: Test-ADTServiceExists -Name 'spooler' -PassThru | Get-Member"
+        "description": "Return the WMI service object. To see all the properties use: Test-ADTServiceExists -Name 'spooler' -PassThru | Get-Member",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "|",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "UseCIM",
+        "description": "Use CIM/WMI to check for the service. This is useful for compatibility with PSADT v3.x.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "-PassThru",
+        "placeholderQuote": ""
       }
     ]
   },
@@ -3298,7 +7937,15 @@
     "parameters": [
       {
         "name": "Tasks",
-        "description": "Specify the scheduled tasks to unblock."
+        "description": "Specify the scheduled tasks to unblock.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       }
     ]
   },
@@ -3309,80 +7956,232 @@
     "link": "https://psappdeploytoolkit.com/docs/reference/functions/Uninstall-ADTApplication",
     "parameters": [
       {
-        "name": "InstalledApplication",
-        "description": "Specifies the [PSADT.Types.InstalledApplication] object to remove. This parameter is typically used when piping Get-ADTApplication to this function."
-      },
-      {
-        "name": "Name",
-        "description": "The name of the application to retrieve information for. Performs a contains match on the application display name by default."
-      },
-      {
-        "name": "NameMatch",
-        "description": "Specifies the type of match to perform on the application name. Valid values are 'Contains', 'Exact', 'Wildcard', and 'Regex'. The default value is 'Contains'."
-      },
-      {
-        "name": "ProductCode",
-        "description": "The product code of the application to retrieve information for."
+        "name": "AdditionalArgumentList",
+        "description": "Adds to the default parameters specified in the config.psd1 file, or the parameters found in QuietUninstallString/UninstallString for EXE applications.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "ApplicationType",
-        "description": "Specifies the type of application to remove. Valid values are 'All', 'MSI', and 'EXE'. The default value is 'All'."
-      },
-      {
-        "name": "IncludeUpdatesAndHotfixes",
-        "description": "Include matches against updates and hotfixes in results."
-      },
-      {
-        "name": "FilterScript",
-        "description": "A script used to filter the results as they're processed."
+        "description": "Specifies the type of application to remove. Valid values are 'All', 'MSI', and 'EXE'. The default value is 'All'.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "MSI",
+        "placeholderQuote": "'"
       },
       {
         "name": "ArgumentList",
-        "description": "Overrides the default MSI parameters specified in the config.psd1 file, or the parameters found in QuietUninstallString/UninstallString for EXE applications."
-      },
-      {
-        "name": "AdditionalArgumentList",
-        "description": "Adds to the default parameters specified in the config.psd1 file, or the parameters found in QuietUninstallString/UninstallString for EXE applications."
-      },
-      {
-        "name": "SecureArgumentList",
-        "description": "Hides all parameters passed to the executable from the Toolkit log file."
-      },
-      {
-        "name": "LoggingOptions",
-        "description": "Overrides the default MSI logging options specified in the config.psd1 file. Default options are: \"/L*v\"."
-      },
-      {
-        "name": "LogFileName",
-        "description": "Overrides the default log file name for MSI applications. The default log file name is generated from the MSI file name. If LogFileName does not end in .log, it will be automatically appended. For uninstallations, by default the product code is resolved to the DisplayName and version of the application."
-      },
-      {
-        "name": "WaitForChildProcesses",
-        "description": "Specifies whether the started process should be considered finished only when any child processes it spawns have finished also."
-      },
-      {
-        "name": "KillChildProcessesWithParent",
-        "description": "Specifies whether any child processes started by the provided executable should be closed when the provided executable closes. This is handy for application installs that open web browsers and other programs that cannot be suppressed."
-      },
-      {
-        "name": "SuccessExitCodes",
-        "description": "List of exit codes to be considered successful. Defaults to values set during ADTSession initialization, otherwise: 0"
-      },
-      {
-        "name": "RebootExitCodes",
-        "description": "List of exit codes to indicate a reboot is required. Defaults to values set during ADTSession initialization, otherwise: 1641, 3010"
-      },
-      {
-        "name": "IgnoreExitCodes",
-        "description": "List the exit codes to ignore or * to ignore all exit codes. Where possible, please use `-SuccessExitCodes` and/or `-RebootExitCodes` instead."
+        "description": "Overrides the default MSI parameters specified in the config.psd1 file, or the parameters found in QuietUninstallString/UninstallString for EXE applications.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "/S",
+        "placeholderQuote": "'"
       },
       {
         "name": "ExitOnProcessFailure",
-        "description": "Automatically closes the active deployment session via Close-ADTSession in the event the process exits with a non-success or non-ignored exit code."
+        "description": "Automatically closes the active deployment session via Close-ADTSession in the event the process exits with a non-success or non-ignored exit code.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "FilterScript",
+        "description": "A script used to filter the results as they're processed.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "{",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "IgnoreExitCodes",
+        "description": "List the exit codes to ignore or * to ignore all exit codes. Where possible, please use `-SuccessExitCodes` and/or `-RebootExitCodes` instead.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "IncludeUpdatesAndHotfixes",
+        "description": "Include matches against updates and hotfixes in results.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "InstalledApplication",
+        "description": "Specifies the [PSADT.Types.InstalledApplication] object to remove. This parameter is typically used when piping Get-ADTApplication to this function.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "KillChildProcessesWithParent",
+        "description": "Specifies whether any child processes started by the provided executable should be closed when the provided executable closes. This is handy for application installs that open web browsers and other programs that cannot be suppressed.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "LogFileName",
+        "description": "Overrides the default log file name for MSI applications. The default log file name is generated from the MSI file name. If LogFileName does not end in .log, it will be automatically appended. For uninstallations, by default the product code is resolved to the DisplayName and version of the application.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "LoggingOptions",
+        "description": "Overrides the default MSI logging options specified in the config.psd1 file. Default options are: \"/L*v\".",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "Name",
+        "description": "The name of the application to retrieve information for. Performs a contains match on the application display name by default.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "Acrobat",
+        "placeholderQuote": "'"
+      },
+      {
+        "name": "NameMatch",
+        "description": "Specifies the type of match to perform on the application name. Valid values are 'Contains', 'Exact', 'Wildcard', and 'Regex'. The default value is 'Contains'.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "PassThru",
-        "description": "Returns a PSADT.Types.ProcessResult object, providing the ExitCode, StdOut, and StdErr output from the uninstallation."
+        "description": "Returns a PSADT.Types.ProcessResult object, providing the ExitCode, StdOut, and StdErr output from the uninstallation.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "ProductCode",
+        "description": "The product code of the application to retrieve information for.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "RebootExitCodes",
+        "description": "List of exit codes to indicate a reboot is required. Defaults to values set during ADTSession initialization, otherwise: 1641, 3010",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "SecureArgumentList",
+        "description": "Hides all parameters passed to the executable from the Toolkit log file.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "SuccessExitCodes",
+        "description": "List of exit codes to be considered successful. Defaults to values set during ADTSession initialization, otherwise: 0",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "WaitForChildProcesses",
+        "description": "Specifies whether the started process should be considered finished only when any child processes it spawns have finished also.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       }
     ]
   },
@@ -3394,7 +8193,15 @@
     "parameters": [
       {
         "name": "FilePath",
-        "description": "Path to the DLL file."
+        "description": "Path to the DLL file.",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "C:\\Test\\DcTLSFileToDMSComp.dll",
+        "placeholderQuote": "\""
       }
     ]
   },
@@ -3420,7 +8227,15 @@
     "parameters": [
       {
         "name": "LoadLoggedOnUserEnvironmentVariables",
-        "description": "If script is running in SYSTEM context, this option allows loading environment variables from the active console user. If no console user exists but users are logged in, such as on terminal servers, then the first logged-in non-console user."
+        "description": "If script is running in SYSTEM context, this option allows loading environment variables from the active console user. If no console user exists but users are logged in, such as on terminal servers, then the first logged-in non-console user.",
+        "required": false,
+        "isSwitch": true,
+        "type": "System.Management.Automation.SwitchParameter",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       }
     ]
   },
@@ -3436,7 +8251,32 @@
     "synopsis": "",
     "description": "",
     "link": "",
-    "parameters": []
+    "parameters": [
+      {
+        "name": "DataFile",
+        "description": "",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.Collections.Hashtable",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "NewData",
+        "description": "",
+        "required": true,
+        "isSwitch": false,
+        "type": "System.Collections.Hashtable",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      }
+    ]
   },
   {
     "name": "Write-ADTLogEntry",
@@ -3445,44 +8285,124 @@
     "link": "https://psappdeploytoolkit.com/docs/reference/functions/Write-ADTLogEntry",
     "parameters": [
       {
-        "name": "Message",
-        "description": "The message to write to the log file or output to the console."
-      },
-      {
-        "name": "Severity",
-        "description": "Defines message type. When writing to console or CMTrace.exe log format, it allows highlighting of message type."
-      },
-      {
-        "name": "Source",
-        "description": "The source of the message being logged."
-      },
-      {
-        "name": "ScriptSection",
-        "description": "The heading for the portion of the script that is being executed."
-      },
-      {
-        "name": "LogType",
-        "description": "Choose whether to write a CMTrace.exe compatible log file or a Legacy text log file."
-      },
-      {
-        "name": "LogFileDirectory",
-        "description": "Set the directory where the log file will be saved."
-      },
-      {
-        "name": "LogFileName",
-        "description": "Set the name of the log file."
+        "name": "DebugMessage",
+        "description": "Specifies that the message is a debug message. Debug messages only get logged if -LogDebugMessage is set to $true.",
+        "required": false,
+        "isSwitch": true,
+        "type": "System.Management.Automation.SwitchParameter",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
         "name": "HostLogStream",
-        "description": "Controls how the log entry is written to the console window."
+        "description": "Controls how the log entry is written to the console window.",
+        "required": false,
+        "isSwitch": false,
+        "type": "PSADT.Module.HostLogStream",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "LogFileDirectory",
+        "description": "Set the directory where the log file will be saved.",
+        "required": false,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "[System.Management.Automation.Language.NullString]::Value",
+        "defaultRaw": "[System.Management.Automation.Language.NullString]::Value",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "LogFileName",
+        "description": "Set the name of the log file.",
+        "required": false,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "[System.Management.Automation.Language.NullString]::Value",
+        "defaultRaw": "[System.Management.Automation.Language.NullString]::Value",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "LogType",
+        "description": "Choose whether to write a CMTrace.exe compatible log file or a Legacy text log file.",
+        "required": false,
+        "isSwitch": false,
+        "type": "PSADT.Module.LogStyle",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "Message",
+        "description": "The message to write to the log file or output to the console.",
+        "required": false,
+        "isSwitch": false,
+        "type": "",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "Installing patch MS15-031",
+        "placeholderQuote": "\""
       },
       {
         "name": "PassThru",
-        "description": "Return the message that was passed to the function."
+        "description": "Return the message that was passed to the function.",
+        "required": false,
+        "isSwitch": true,
+        "type": "System.Management.Automation.SwitchParameter",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
       },
       {
-        "name": "DebugMessage",
-        "description": "Specifies that the message is a debug message. Debug messages only get logged if -LogDebugMessage is set to $true."
+        "name": "ScriptSection",
+        "description": "The heading for the portion of the script that is being executed.",
+        "required": false,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "[System.Management.Automation.Language.NullString]::Value",
+        "defaultRaw": "[System.Management.Automation.Language.NullString]::Value",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "Severity",
+        "description": "Defines message type. When writing to console or CMTrace.exe log format, it allows highlighting of message type.",
+        "required": true,
+        "isSwitch": false,
+        "type": "PSADT.Module.LogSeverity",
+        "defaultValue": "",
+        "defaultRaw": "",
+        "defaultQuote": "",
+        "placeholder": "",
+        "placeholderQuote": ""
+      },
+      {
+        "name": "Source",
+        "description": "The source of the message being logged.",
+        "required": false,
+        "isSwitch": false,
+        "type": "System.String",
+        "defaultValue": "[System.Management.Automation.Language.NullString]::Value",
+        "defaultRaw": "[System.Management.Automation.Language.NullString]::Value",
+        "defaultQuote": "",
+        "placeholder": "Add-Patch",
+        "placeholderQuote": "'"
       }
     ]
   }

--- a/src/js/editor.js
+++ b/src/js/editor.js
@@ -1,203 +1,450 @@
-// Modern command explorer with parameter details
-(() => {
-  const builderEl = document.getElementById('builder');
-  if (!builderEl) return;
+function stripQuotes(value) {
+  if (!value) return '';
+  const trimmed = String(value).trim();
+  const match = trimmed.match(/^(["'])([\s\S]*)\1$/);
+  if (!match) return trimmed;
+  return match[2];
+}
 
-  const boxesEl = document.getElementById('command-boxes');
-  const detailEl = document.getElementById('command-detail');
-  const editorEl = document.getElementById('editor-area');
-  const searchEl = document.getElementById('command-search');
-
-  let commands = [];
-  let filtered = [];
-  let activeName = '';
-
-  function insertCommand(cmd) {
-    if (!editorEl) return;
-    const current = editorEl.textContent;
-    editorEl.textContent = current ? `${current}\n${cmd}` : cmd;
+function createParameterState(command) {
+  const state = {};
+  if (!command || !Array.isArray(command.parameters)) {
+    return state;
   }
+  command.parameters.forEach(param => {
+    const defaultValue = stripQuotes(param.defaultValue || '');
+    const placeholder = stripQuotes(param.placeholder || '');
+    const baseValue = defaultValue || placeholder;
+    const defaultRaw = (param.defaultRaw || '').toLowerCase();
+    const switchEnabled =
+      param.isSwitch && (param.required || defaultRaw === '$true');
+    state[param.name] = {
+      enabled: param.isSwitch ? switchEnabled : !!param.required,
+      value: param.isSwitch ? '' : baseValue,
+    };
+  });
+  return state;
+}
 
-  function highlightActive(name) {
-    activeName = name;
-    if (!boxesEl) return;
-    boxesEl.querySelectorAll('.cmd-box').forEach((box) => {
-      const isActive = box.dataset.command === name;
-      box.classList.toggle('active', isActive);
-      box.setAttribute('aria-pressed', isActive ? 'true' : 'false');
-    });
+function inferQuoteChar(param) {
+  if (!param) return '';
+  if (param.defaultQuote) return param.defaultQuote;
+  if (param.placeholderQuote) return param.placeholderQuote;
+  if (param.type && /string$/i.test(param.type)) return '"';
+  return '';
+}
+
+function formatParameterValue(param, rawValue) {
+  if (!param) return '';
+  const value = (rawValue || '').toString().trim();
+  if (!value) return '';
+  if (/^(['"]).*\1$/.test(value)) {
+    return value;
   }
-
-  function renderEmptyDetail(message) {
-    if (!detailEl) return;
-    detailEl.innerHTML = '';
-    detailEl.classList.add('empty');
-    const p = document.createElement('p');
-    p.textContent = message;
-    detailEl.appendChild(p);
+  let quote = inferQuoteChar(param);
+  if (!quote && /\s/.test(value)) {
+    quote = '"';
   }
-
-  function showCommandDetail(cmd) {
-    if (!detailEl) return;
-    highlightActive(cmd.name);
-    detailEl.classList.remove('empty');
-    detailEl.innerHTML = '';
-
-    const header = document.createElement('div');
-    header.className = 'cmd-detail-header';
-
-    const titleWrap = document.createElement('div');
-    titleWrap.className = 'cmd-detail-title';
-    const title = document.createElement('h3');
-    title.textContent = cmd.name;
-    titleWrap.appendChild(title);
-    if (cmd.synopsis) {
-      const synopsis = document.createElement('p');
-      synopsis.className = 'cmd-detail-synopsis';
-      synopsis.textContent = cmd.synopsis;
-      titleWrap.appendChild(synopsis);
-    }
-    header.appendChild(titleWrap);
-
-    const actions = document.createElement('div');
-    actions.className = 'cmd-detail-actions';
-    const addBtn = document.createElement('button');
-    addBtn.type = 'button';
-    addBtn.className = 'btn btn-ghost cmd-detail-add';
-    addBtn.textContent = 'Add to editor';
-    addBtn.addEventListener('click', () => insertCommand(cmd.name));
-    actions.appendChild(addBtn);
-    if (cmd.link) {
-      const link = document.createElement('a');
-      link.href = cmd.link;
-      link.target = '_blank';
-      link.rel = 'noreferrer';
-      link.className = 'cmd-detail-link';
-      link.textContent = 'View documentation';
-      actions.appendChild(link);
-    }
-    header.appendChild(actions);
-    detailEl.appendChild(header);
-
-    if (cmd.parameters && cmd.parameters.length) {
-      const list = document.createElement('div');
-      list.className = 'cmd-param-list';
-      cmd.parameters.forEach((param) => {
-        const item = document.createElement('div');
-        item.className = 'cmd-param';
-
-        const nameRow = document.createElement('div');
-        nameRow.className = 'cmd-param-header';
-        const nameEl = document.createElement('code');
-        nameEl.className = 'cmd-param-name';
-        nameEl.textContent = `-${param.name}`;
-        nameRow.appendChild(nameEl);
-        item.appendChild(nameRow);
-
-        if (param.description) {
-          const desc = document.createElement('p');
-          desc.className = 'cmd-param-desc';
-          desc.textContent = param.description;
-          item.appendChild(desc);
-        }
-        list.appendChild(item);
-      });
-      detailEl.appendChild(list);
-    } else {
-      const noParams = document.createElement('p');
-      noParams.className = 'cmd-no-params';
-      noParams.textContent = 'This command does not document any parameters.';
-      detailEl.appendChild(noParams);
-    }
+  if (!quote) {
+    return value;
   }
+  const escaped = value.replace(new RegExp(quote, 'g'), `\\${quote}`);
+  return `${quote}${escaped}${quote}`;
+}
 
-  function renderCommands(list) {
-    if (!boxesEl) return;
-    boxesEl.innerHTML = '';
-    if (!list.length) {
-      const msg = document.createElement('div');
-      msg.className = 'cmd-empty';
-      msg.textContent = 'No commands found.';
-      boxesEl.appendChild(msg);
-      highlightActive('');
-      renderEmptyDetail('Select a command to view parameters.');
+function buildCommandString(command, state) {
+  if (!command) return '';
+  const resolvedState = state || createParameterState(command);
+  const parts = [command.name];
+  const parameters = Array.isArray(command.parameters)
+    ? command.parameters
+    : [];
+  parameters.forEach(param => {
+    const paramState = resolvedState[param.name] || {
+      enabled: !!param.required,
+      value: stripQuotes(param.defaultValue || param.placeholder || ''),
+    };
+    if (param.isSwitch) {
+      if (paramState.enabled || param.required) {
+        parts.push(`-${param.name}`);
+      }
       return;
     }
-    list.forEach((cmd) => {
-      const box = document.createElement('div');
-      box.className = 'cmd-box' + (cmd.name === activeName ? ' active' : '');
-      box.textContent = cmd.name;
-      box.draggable = true;
-      box.tabIndex = 0;
-      box.dataset.command = cmd.name;
-      box.setAttribute('role', 'button');
-      box.setAttribute('aria-pressed', cmd.name === activeName ? 'true' : 'false');
-      box.addEventListener('dragstart', (e) => {
-        e.dataTransfer.setData('text/plain', cmd.name);
-      });
-      box.addEventListener('click', () => {
-        showCommandDetail(cmd);
-      });
-      box.addEventListener('dblclick', (e) => {
-        e.preventDefault();
-        insertCommand(cmd.name);
-      });
-      box.addEventListener('keydown', (e) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault();
-          showCommandDetail(cmd);
-        } else if (e.key === 'Insert') {
-          insertCommand(cmd.name);
-        }
-      });
-      boxesEl.appendChild(box);
-    });
-  }
-
-  function applyFilter(term) {
-    const normalized = term.trim().toLowerCase();
-    filtered = !normalized
-      ? commands.slice()
-      : commands.filter((cmd) => {
-          const haystack = `${cmd.name} ${cmd.synopsis || ''} ${cmd.description || ''}`.toLowerCase();
-          return haystack.includes(normalized);
-        });
-    if (activeName && !filtered.some((cmd) => cmd.name === activeName)) {
-      activeName = '';
-      renderEmptyDetail('Select a command to view parameters.');
+    const enabled = param.required || paramState.enabled;
+    if (!enabled) {
+      return;
     }
-    renderCommands(filtered);
-  }
+    let value = paramState.value;
+    if (!value) {
+      value = param.defaultValue || param.placeholder || '';
+    }
+    const formatted = formatParameterValue(param, value);
+    if (formatted) {
+      parts.push(`-${param.name} ${formatted}`);
+    } else {
+      parts.push(`-${param.name}`);
+    }
+  });
+  return parts.join(' ');
+}
 
-  if (editorEl) {
-    editorEl.addEventListener('dragover', (e) => e.preventDefault());
-    editorEl.addEventListener('drop', (e) => {
-      e.preventDefault();
-      const text = e.dataTransfer.getData('text/plain');
-      if (text) insertCommand(text);
-    });
-  }
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = {
+    stripQuotes,
+    createParameterState,
+    formatParameterValue,
+    buildCommandString,
+  };
+}
 
-  async function init() {
-    if (!boxesEl) return;
-    try {
-      const res = await fetch('src/data/command-metadata.json');
-      const data = await res.json();
-      commands = Array.isArray(data) ? data : [];
-      filtered = commands.slice();
-      renderCommands(filtered);
-      renderEmptyDetail('Select a command to view parameters.');
-      if (searchEl) {
-        searchEl.addEventListener('input', () => applyFilter(searchEl.value || ''));
+if (typeof window !== 'undefined' && typeof document !== 'undefined') {
+  (() => {
+    const builderEl = document.getElementById('builder');
+    if (!builderEl) return;
+
+    const boxesEl = document.getElementById('command-boxes');
+    const detailEl = document.getElementById('command-detail');
+    const editorEl = document.getElementById('editor-area');
+    const searchEl = document.getElementById('command-search');
+
+    let commands = [];
+    let filtered = [];
+    let activeName = '';
+    const commandStates = new Map();
+
+    function getSafeId(commandName, paramName, suffix) {
+      return `${commandName}-${paramName}-${suffix}`.replace(/[^A-Za-z0-9_-]/g, '-');
+    }
+
+    function getCommandState(cmd) {
+      if (!commandStates.has(cmd.name)) {
+        commandStates.set(cmd.name, createParameterState(cmd));
       }
-    } catch (err) {
-      const msg = document.createElement('div');
-      msg.className = 'cmd-empty';
-      msg.textContent = 'Failed to load commands.';
-      boxesEl.appendChild(msg);
-      console.error(err);
+      return commandStates.get(cmd.name);
     }
-  }
 
-  init();
-})();
+    function insertCommand(cmdText) {
+      if (!editorEl) return;
+      const current = editorEl.textContent;
+      editorEl.textContent = current ? `${current}\n${cmdText}` : cmdText;
+    }
+
+    function highlightActive(name) {
+      activeName = name;
+      if (!boxesEl) return;
+      boxesEl.querySelectorAll('.cmd-box').forEach(box => {
+        const isActive = box.dataset.command === name;
+        box.classList.toggle('active', isActive);
+        box.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+      });
+    }
+
+    function renderEmptyDetail(message) {
+      if (!detailEl) return;
+      detailEl.innerHTML = '';
+      detailEl.classList.add('empty');
+      const p = document.createElement('p');
+      p.textContent = message;
+      detailEl.appendChild(p);
+    }
+
+    function renderParameter(cmd, param) {
+      const item = document.createElement('div');
+      item.className = 'cmd-param';
+      const state = getCommandState(cmd);
+      if (!state[param.name]) {
+        state[param.name] = {
+          enabled: !!param.required,
+          value: stripQuotes(param.defaultValue || param.placeholder || ''),
+        };
+      }
+      const paramState = state[param.name];
+
+      const header = document.createElement('div');
+      header.className = 'cmd-param-header';
+      item.appendChild(header);
+
+      const toggleWrap = document.createElement('div');
+      toggleWrap.className = 'cmd-param-toggle';
+      header.appendChild(toggleWrap);
+
+      const toggleId = getSafeId(cmd.name, param.name, 'toggle');
+      const checkbox = document.createElement('input');
+      checkbox.type = 'checkbox';
+      checkbox.id = toggleId;
+      checkbox.className = 'cmd-param-checkbox';
+      checkbox.checked = param.required ? true : !!paramState.enabled;
+      if (param.required) {
+        checkbox.disabled = true;
+        checkbox.setAttribute('aria-disabled', 'true');
+      }
+      toggleWrap.appendChild(checkbox);
+
+      const label = document.createElement('label');
+      label.className = 'cmd-param-label';
+      label.setAttribute('for', toggleId);
+      const nameCode = document.createElement('code');
+      nameCode.className = 'cmd-param-name';
+      nameCode.textContent = `-${param.name}`;
+      label.appendChild(nameCode);
+      if (param.required) {
+        const requiredBadge = document.createElement('span');
+        requiredBadge.className = 'cmd-param-required';
+        requiredBadge.textContent = 'Required';
+        label.appendChild(requiredBadge);
+      }
+      if (param.isSwitch && !param.required) {
+        label.appendChild(document.createTextNode(' (toggle)'));
+      }
+      toggleWrap.appendChild(label);
+
+      if (param.type) {
+        const type = document.createElement('span');
+        type.className = 'cmd-param-type';
+        type.textContent = param.type;
+        header.appendChild(type);
+      }
+
+      let descId = '';
+      if (param.description) {
+        const desc = document.createElement('p');
+        desc.className = 'cmd-param-desc';
+        descId = getSafeId(cmd.name, param.name, 'desc');
+        desc.id = descId;
+        desc.textContent = param.description;
+        item.appendChild(desc);
+      }
+
+      const metaEntries = [];
+      if (param.defaultRaw || param.defaultValue) {
+        const defaultDisplay = param.defaultRaw || param.defaultValue;
+        metaEntries.push({ label: 'Default', value: defaultDisplay, code: true });
+      }
+      if (param.placeholder) {
+        const placeholderValue = param.placeholderQuote
+          ? `${param.placeholderQuote}${param.placeholder}${param.placeholderQuote}`
+          : param.placeholder;
+        metaEntries.push({ label: 'Example', value: placeholderValue, code: true });
+      }
+
+      if (metaEntries.length) {
+        const meta = document.createElement('dl');
+        meta.className = 'cmd-param-meta';
+        metaEntries.forEach(entry => {
+          const dt = document.createElement('dt');
+          dt.textContent = entry.label;
+          const dd = document.createElement('dd');
+          if (entry.code) {
+            const codeEl = document.createElement('code');
+            codeEl.textContent = entry.value;
+            dd.appendChild(codeEl);
+          } else {
+            dd.textContent = entry.value;
+          }
+          meta.appendChild(dt);
+          meta.appendChild(dd);
+        });
+        item.appendChild(meta);
+      }
+
+      if (!param.isSwitch) {
+        const input = document.createElement('input');
+        input.type = 'text';
+        input.className = 'cmd-param-input';
+        input.value = paramState.value || '';
+        input.placeholder = param.placeholder || '';
+        input.disabled = param.required ? false : !paramState.enabled;
+        if (descId) {
+          input.setAttribute('aria-describedby', descId);
+        }
+        input.addEventListener('input', () => {
+          state[param.name].value = input.value;
+        });
+        checkbox.addEventListener('change', () => {
+          if (param.required) return;
+          state[param.name].enabled = checkbox.checked;
+          if (checkbox.checked && !input.value) {
+            input.value = stripQuotes(
+              param.defaultValue || param.placeholder || ''
+            );
+            state[param.name].value = input.value;
+          }
+          input.disabled = !checkbox.checked;
+          if (checkbox.checked) {
+            input.focus();
+          }
+        });
+        item.appendChild(input);
+      } else {
+        checkbox.addEventListener('change', () => {
+          if (param.required) return;
+          state[param.name].enabled = checkbox.checked;
+        });
+      }
+
+      return item;
+    }
+
+    function showCommandDetail(cmd) {
+      if (!detailEl) return;
+      highlightActive(cmd.name);
+      detailEl.classList.remove('empty');
+      detailEl.innerHTML = '';
+
+      const header = document.createElement('div');
+      header.className = 'cmd-detail-header';
+
+      const titleWrap = document.createElement('div');
+      titleWrap.className = 'cmd-detail-title';
+      const title = document.createElement('h3');
+      title.textContent = cmd.name;
+      titleWrap.appendChild(title);
+      if (cmd.synopsis) {
+        const synopsis = document.createElement('p');
+        synopsis.className = 'cmd-detail-synopsis';
+        synopsis.textContent = cmd.synopsis;
+        titleWrap.appendChild(synopsis);
+      }
+      header.appendChild(titleWrap);
+
+      const actions = document.createElement('div');
+      actions.className = 'cmd-detail-actions';
+      const addBtn = document.createElement('button');
+      addBtn.type = 'button';
+      addBtn.className = 'btn btn-ghost cmd-detail-add';
+      addBtn.textContent = 'Add to editor';
+      addBtn.addEventListener('click', () => {
+        const state = getCommandState(cmd);
+        const commandText = buildCommandString(cmd, state);
+        insertCommand(commandText);
+      });
+      actions.appendChild(addBtn);
+      if (cmd.link) {
+        const link = document.createElement('a');
+        link.href = cmd.link;
+        link.target = '_blank';
+        link.rel = 'noreferrer';
+        link.className = 'cmd-detail-link';
+        link.textContent = 'View documentation';
+        actions.appendChild(link);
+      }
+      header.appendChild(actions);
+      detailEl.appendChild(header);
+
+      if (cmd.parameters && cmd.parameters.length) {
+        const list = document.createElement('div');
+        list.className = 'cmd-param-list';
+        cmd.parameters.forEach(param => {
+          const rendered = renderParameter(cmd, param);
+          list.appendChild(rendered);
+        });
+        detailEl.appendChild(list);
+      } else {
+        const noParams = document.createElement('p');
+        noParams.className = 'cmd-no-params';
+        noParams.textContent = 'This command does not document any parameters.';
+        detailEl.appendChild(noParams);
+      }
+    }
+
+    function renderCommands(list) {
+      if (!boxesEl) return;
+      boxesEl.innerHTML = '';
+      if (!list.length) {
+        const msg = document.createElement('div');
+        msg.className = 'cmd-empty';
+        msg.textContent = 'No commands found.';
+        boxesEl.appendChild(msg);
+        highlightActive('');
+        renderEmptyDetail('Select a command to view parameters.');
+        return;
+      }
+      list.forEach(cmd => {
+        const box = document.createElement('div');
+        box.className = 'cmd-box' + (cmd.name === activeName ? ' active' : '');
+        box.textContent = cmd.name;
+        box.draggable = true;
+        box.tabIndex = 0;
+        box.dataset.command = cmd.name;
+        box.setAttribute('role', 'button');
+        box.setAttribute('aria-pressed', cmd.name === activeName ? 'true' : 'false');
+        box.addEventListener('dragstart', e => {
+          const state = getCommandState(cmd);
+          const commandText = buildCommandString(cmd, state);
+          e.dataTransfer.setData('text/plain', commandText);
+        });
+        box.addEventListener('click', () => {
+          showCommandDetail(cmd);
+        });
+        box.addEventListener('dblclick', e => {
+          e.preventDefault();
+          const state = getCommandState(cmd);
+          const commandText = buildCommandString(cmd, state);
+          insertCommand(commandText);
+        });
+        box.addEventListener('keydown', e => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            showCommandDetail(cmd);
+          } else if (e.key === 'Insert') {
+            const state = getCommandState(cmd);
+            const commandText = buildCommandString(cmd, state);
+            insertCommand(commandText);
+          }
+        });
+        boxesEl.appendChild(box);
+      });
+    }
+
+    function applyFilter(term) {
+      const normalized = term.trim().toLowerCase();
+      filtered = !normalized
+        ? commands.slice()
+        : commands.filter(cmd => {
+            const haystack = `${cmd.name} ${cmd.synopsis || ''} ${
+              cmd.description || ''
+            }`.toLowerCase();
+            return haystack.includes(normalized);
+          });
+      if (activeName && !filtered.some(cmd => cmd.name === activeName)) {
+        activeName = '';
+        renderEmptyDetail('Select a command to view parameters.');
+      }
+      renderCommands(filtered);
+    }
+
+    if (editorEl) {
+      editorEl.addEventListener('dragover', e => e.preventDefault());
+      editorEl.addEventListener('drop', e => {
+        e.preventDefault();
+        const text = e.dataTransfer.getData('text/plain');
+        if (text) insertCommand(text);
+      });
+    }
+
+    async function init() {
+      if (!boxesEl) return;
+      try {
+        const res = await fetch('src/data/command-metadata.json');
+        const data = await res.json();
+        commands = Array.isArray(data) ? data : [];
+        filtered = commands.slice();
+        renderCommands(filtered);
+        renderEmptyDetail('Select a command to view parameters.');
+        if (searchEl) {
+          searchEl.addEventListener('input', () =>
+            applyFilter(searchEl.value || '')
+          );
+        }
+      } catch (err) {
+        const msg = document.createElement('div');
+        msg.className = 'cmd-empty';
+        msg.textContent = 'Failed to load commands.';
+        boxesEl.appendChild(msg);
+        console.error(err);
+      }
+    }
+
+    init();
+  })();
+}

--- a/styles.css
+++ b/styles.css
@@ -1076,6 +1076,37 @@ textarea {
   border-radius: var(--radius-md);
   padding: var(--space-sm);
   background: color-mix(in srgb, var(--color-surface) 92%, var(--color-bg) 8%);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2xs);
+}
+
+.cmd-param-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-sm);
+}
+
+.cmd-param-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2xs);
+}
+
+.cmd-param-checkbox {
+  width: 1.1rem;
+  height: 1.1rem;
+  accent-color: var(--color-accent);
+}
+
+.cmd-param-label {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2xs);
+  cursor: pointer;
+  font-size: var(--fs-300);
 }
 
 .cmd-param-name {
@@ -1084,10 +1115,67 @@ textarea {
   font-size: var(--fs-300);
 }
 
+.cmd-param-required {
+  display: inline-flex;
+  align-items: center;
+  padding: 0 var(--space-3xs);
+  border-radius: var(--radius-pill);
+  background: color-mix(in srgb, var(--color-accent) 18%, transparent 82%);
+  color: var(--color-accent-strong);
+  font-size: var(--fs-200);
+  font-weight: 600;
+}
+
+.cmd-param-type {
+  font-size: var(--fs-200);
+  font-family: var(--font-mono);
+  color: var(--color-muted);
+}
+
 .cmd-param-desc {
   margin: var(--space-2xs) 0 0 0;
   font-size: var(--fs-300);
   line-height: 1.45;
+}
+
+.cmd-param-meta {
+  margin: 0;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  column-gap: var(--space-xs);
+  row-gap: var(--space-3xs);
+  font-size: var(--fs-200);
+  color: var(--color-muted);
+}
+
+.cmd-param-meta dt {
+  font-weight: 600;
+}
+
+.cmd-param-meta dd {
+  margin: 0;
+}
+
+.cmd-param-input {
+  width: 100%;
+  padding: var(--space-2xs) var(--space-xs);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  font-family: var(--font-mono);
+  font-size: var(--fs-300);
+  transition: border-color var(--transition-fast),
+    box-shadow var(--transition-fast),
+    background-color var(--transition-fast);
+}
+
+.cmd-param-input:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+.cmd-param-input:disabled {
+  opacity: 0.65;
 }
 
 .cmd-no-params {

--- a/tests/js/editor.test.js
+++ b/tests/js/editor.test.js
@@ -1,0 +1,82 @@
+const {
+  createParameterState,
+  buildCommandString,
+  formatParameterValue,
+} = require('../../src/js/editor.js');
+
+describe('editor command composition', () => {
+  const command = {
+    name: 'Test-Command',
+    parameters: [
+      {
+        name: 'Name',
+        required: true,
+        isSwitch: false,
+        type: 'System.String',
+        defaultValue: '',
+        defaultRaw: '',
+        defaultQuote: '',
+        placeholder: 'example',
+        placeholderQuote: '"',
+      },
+      {
+        name: 'OptionalPath',
+        required: false,
+        isSwitch: false,
+        type: 'System.String',
+        defaultValue: '',
+        defaultRaw: '',
+        defaultQuote: '',
+        placeholder: 'C:/Program Files/App',
+        placeholderQuote: '"',
+      },
+      {
+        name: 'Force',
+        required: false,
+        isSwitch: true,
+        type: 'switch',
+        defaultValue: '',
+        defaultRaw: '',
+        defaultQuote: '',
+        placeholder: '',
+        placeholderQuote: '',
+      },
+    ],
+  };
+
+  test('seeds required parameters with placeholder defaults', () => {
+    const state = createParameterState(command);
+    expect(state.Name).toEqual({ enabled: true, value: 'example' });
+    expect(state.OptionalPath.enabled).toBe(false);
+    expect(state.OptionalPath.value).toBe('C:/Program Files/App');
+  });
+
+  test('builds command string with required parameters only', () => {
+    const state = createParameterState(command);
+    const built = buildCommandString(command, state);
+    expect(built).toBe('Test-Command -Name "example"');
+  });
+
+  test('includes optional values and switches when enabled', () => {
+    const state = createParameterState(command);
+    state.OptionalPath.enabled = true;
+    state.OptionalPath.value = '';
+    state.Force.enabled = true;
+    const built = buildCommandString(command, state);
+    expect(built).toBe(
+      'Test-Command -Name "example" -OptionalPath "C:/Program Files/App" -Force'
+    );
+  });
+
+  test('respects user supplied quoting', () => {
+    const literal = formatParameterValue(command.parameters[1], "'custom value'");
+    expect(literal).toBe("'custom value'");
+    const state = createParameterState(command);
+    state.OptionalPath.enabled = true;
+    state.OptionalPath.value = "'custom value'";
+    const built = buildCommandString(command, state);
+    expect(built).toBe(
+      "Test-Command -Name \"example\" -OptionalPath 'custom value'"
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- extend the command metadata generation script to capture parameter requirements, defaults, and sample placeholders
- update the command builder to render accessible parameter controls and assemble full commands from user selections
- style the new controls and add tests that exercise the composition logic and placeholder handling

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cbd74ccd58832495331d273fd6a06e