### PR TITLE
Move theme toggle to header

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,6 +89,14 @@
           <span class="nav-toggle-label">Menu</span>
         </button>
         <div class="header-menu" data-nav-menu>
+          <div class="header-theme" role="group" aria-label="Theme">
+            <svg class="icon" aria-hidden="true"><use href="#ic-theme" /></svg>
+            <label class="header-theme-label" for="header-color-mode">Theme</label>
+            <select id="header-color-mode" class="header-theme-select">
+              <option value="light">Light</option>
+              <option value="dark">Dark</option>
+            </select>
+          </div>
           <nav
             class="header-links"
             id="primary-nav"
@@ -314,132 +322,6 @@
             </section>
 
             <aside class="tools" aria-label="Tools">
-              <div class="card">
-                <h3 class="card-title">
-                  <svg class="icon"><use href="#ic-theme" /></svg><span>Theme</span>
-                </h3>
-                <div class="theme-picker" title="Choose accent color">
-                  <span class="theme-label">Accent</span>
-                  <div
-                    class="swatches"
-                    id="accent-swatches"
-                    aria-label="Accent presets"
-                  >
-                    <button
-                      class="swatch"
-                      data-color="#175BEB"
-                      style="--c: #175beb"
-                      aria-label="Brand Blue"
-                    ></button>
-                    <button
-                      class="swatch"
-                      data-color="#4776E6"
-                      style="--c: #4776e6"
-                      aria-label="Blue"
-                    ></button>
-                    <button
-                      class="swatch"
-                      data-color="#8E54E9"
-                      style="--c: #8e54e9"
-                      aria-label="Violet"
-                    ></button>
-                    <button
-                      class="swatch"
-                      data-color="#EC008C"
-                      style="--c: #ec008c"
-                      aria-label="Magenta"
-                    ></button>
-                    <button
-                      class="swatch"
-                      data-color="#FFC225"
-                      style="--c: #ffc225"
-                      aria-label="Gold"
-                    ></button>
-                    <button
-                      class="swatch"
-                      data-color="#1FB381"
-                      style="--c: #1fb381"
-                      aria-label="Green"
-                    ></button>
-                  </div>
-                  <input
-                    id="accent"
-                    class="accent"
-                    type="color"
-                    value="#175BEB"
-                    aria-label="Custom accent color"
-                  />
-                </div>
-                <div
-                  class="theme-picker"
-                  title="Choose background color"
-                  style="margin-top: 8px"
-                >
-                  <span class="theme-label">Background</span>
-                  <div
-                    class="swatches"
-                    id="bg-swatches"
-                    aria-label="Background presets"
-                  >
-                    <button
-                      class="swatch"
-                      data-color="#FAF8FF"
-                      style="--c: #faf8ff"
-                      aria-label="Cloudcook Base"
-                    ></button>
-                    <button
-                      class="swatch"
-                      data-color="#FFFFFF"
-                      style="--c: #ffffff"
-                      aria-label="White"
-                    ></button>
-                    <button
-                      class="swatch"
-                      data-color="#E9E8FF"
-                      style="--c: #e9e8ff"
-                      aria-label="Lavender"
-                    ></button>
-                    <button
-                      class="swatch"
-                      data-color="#FFFDF7"
-                      style="--c: #fffdf7"
-                      aria-label="Ivory"
-                    ></button>
-                    <button
-                      class="swatch"
-                      data-color="#F6F6FF"
-                      style="--c: #f6f6ff"
-                      aria-label="Mist"
-                    ></button>
-                    <button
-                      class="swatch"
-                      data-color="#F3F1FE"
-                      style="--c: #f3f1fe"
-                      aria-label="Lilac"
-                    ></button>
-                  </div>
-                  <input
-                    id="background"
-                    class="accent"
-                    type="color"
-                    value="#FAF8FF"
-                    aria-label="Custom background color"
-                  />
-                </div>
-                <div
-                  class="theme-picker"
-                  title="Choose color mode"
-                  style="margin-top: 8px"
-                >
-                  <span class="theme-label">Mode</span>
-                  <select id="color-mode" aria-label="Color mode">
-                    <option value="auto">Auto</option>
-                    <option value="light">Light</option>
-                    <option value="dark">Dark</option>
-                    <option value="hc">High Contrast</option>
-                  </select>
-                </div>
-              </div>
               <details
                 class="card panel variable-card"
                 id="variable-panel"

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -30,7 +30,7 @@
   const swatchesEl = document.getElementById('accent-swatches');
   const bgEl = document.getElementById('background');
   const bgSwatchesEl = document.getElementById('bg-swatches');
-  const modeSel = document.getElementById('color-mode');
+  const modeSel = document.getElementById('header-color-mode');
   const telemetryToggle = document.getElementById('telemetry-toggle');
   const cacheToggle = document.getElementById('cache-toggle');
   const builderTrigger = document.querySelector('[data-open-builder]');
@@ -196,22 +196,28 @@
   });
 
   function applyMode(mode) {
-    document.documentElement.removeAttribute('data-theme');
-    if (mode === 'dark' || mode === 'hc') {
-      document.documentElement.setAttribute('data-theme', mode);
+    if (mode === 'dark') {
+      document.documentElement.setAttribute('data-theme', 'dark');
+      return;
     }
+    document.documentElement.removeAttribute('data-theme');
   }
   if (modeSel) {
     const prefersDark = window.matchMedia(
       '(prefers-color-scheme: dark)',
     ).matches;
-    const saved = localStorage.getItem('color-mode') || 'auto';
-    modeSel.value = saved;
-    applyMode(saved === 'auto' ? (prefersDark ? 'dark' : 'light') : saved);
+    const saved = localStorage.getItem('color-mode');
+    const initial = saved === 'dark' || saved === 'light'
+      ? saved
+      : prefersDark
+        ? 'dark'
+        : 'light';
+    modeSel.value = initial;
+    applyMode(initial);
     modeSel.addEventListener('change', (e) => {
-      const val = e.target.value;
+      const val = e.target.value === 'dark' ? 'dark' : 'light';
       localStorage.setItem('color-mode', val);
-      applyMode(val === 'auto' ? (prefersDark ? 'dark' : 'light') : val);
+      applyMode(val);
     });
   }
 

--- a/styles.css
+++ b/styles.css
@@ -447,6 +447,45 @@ ul {
   gap: var(--space-xs);
 }
 
+.header-theme {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2xs);
+  padding: var(--space-2xs) var(--space-sm);
+  border-radius: var(--radius-pill);
+  border: 1px solid color-mix(in srgb, var(--color-border) 85%, transparent 15%);
+  background: color-mix(in srgb, var(--color-surface) 96%, transparent 4%);
+  color: var(--color-muted);
+  font-size: var(--fs-300);
+  font-weight: 600;
+  width: 100%;
+}
+
+.header-theme .icon {
+  width: 18px;
+  height: 18px;
+}
+
+.header-theme-label {
+  font-size: inherit;
+}
+
+.header-theme-select {
+  border-radius: var(--radius-pill);
+  border: 1px solid color-mix(in srgb, var(--color-border) 80%, transparent 20%);
+  background: color-mix(in srgb, var(--color-surface) 94%, transparent 6%);
+  color: var(--color-text);
+  font-weight: 600;
+  font-size: var(--fs-300);
+  padding: var(--space-3xs) var(--space-2xs);
+}
+
+.header-theme-select:focus {
+  outline: none;
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-accent) 22%, transparent);
+}
+
 .telemetry-toggle {
   display: inline-flex;
   align-items: center;
@@ -515,6 +554,11 @@ ul {
     flex-wrap: wrap;
     justify-content: flex-end;
     gap: var(--space-2xs);
+  }
+
+  .header-theme {
+    justify-content: center;
+    width: auto;
   }
 
   .telemetry-toggle {

--- a/tests/js/variables.test.js
+++ b/tests/js/variables.test.js
@@ -35,7 +35,7 @@ const baseMarkup = `
       <div id="accent-swatches"></div>
       <input id="background" />
       <div id="bg-swatches"></div>
-      <select id="color-mode"></select>
+      <select id="header-color-mode"></select>
       <label for="telemetry-toggle"></label>
       <input type="checkbox" id="telemetry-toggle" />
       <div class="variable-card">


### PR DESCRIPTION
## Summary
- add a light/dark theme selector to the header navigation
- remove the old theme card from the tools sidebar
- update theme initialization logic, styles, and tests to use the new selector

## Testing
- npm test *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_68cbf12a60d48324838559595cc022fe