### PR TITLE
Relax hero sidebar breakpoint

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -677,9 +677,10 @@ ul {
   }
 }
 
-@media (min-width: 1180px) {
+@media (min-width: 880px) {
   .hero-layout {
-    grid-template-columns: minmax(0, 320px) minmax(0, 1fr) minmax(0, 320px);
+    grid-template-columns: minmax(0, clamp(220px, 22vw, 280px)) minmax(0, 1fr)
+      minmax(0, clamp(220px, 22vw, 280px));
     grid-template-areas: 'scenarios hero variables';
     align-items: stretch;
   }


### PR DESCRIPTION
## Summary
- lower the hero layout breakpoint so the scenarios list and variable helper flank the hero sooner
- tighten the sidebar column clamps to keep the three-column layout stable on mid-size viewports

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc006edc1883248ce9dd65d3a5f096