### PR TITLE
Adjust hero layout spacing for hero sidebar cards

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -645,7 +645,7 @@ ul {
 
 .hero-layout {
   display: grid;
-  gap: clamp(var(--space-md), 5vw, var(--space-xl));
+  gap: clamp(var(--space-md), 4vw, var(--space-xl));
   grid-template-areas: 'hero' 'scenarios' 'variables';
 }
 
@@ -679,8 +679,8 @@ ul {
 
 @media (min-width: 880px) {
   .hero-layout {
-    grid-template-columns: minmax(0, clamp(220px, 22vw, 280px)) minmax(0, 1fr)
-      minmax(0, clamp(220px, 22vw, 280px));
+    grid-template-columns: minmax(0, clamp(240px, 27vw, 360px)) minmax(0, 1fr)
+      minmax(0, clamp(240px, 27vw, 360px));
     grid-template-areas: 'scenarios hero variables';
     align-items: stretch;
   }


### PR DESCRIPTION
## Summary
- reduce the large horizontal gap in the hero layout and allow sidebars to grow with the viewport

## Testing
- npm test -- --runTestsByPath *(fails: missing jest-environment-jsdom runtime in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc04f9391c832494443af6d6c1780b