### PR TITLE
Simplify hero layout and relocate variable helper

### DIFF
--- a/index.html
+++ b/index.html
@@ -129,78 +129,52 @@
     <main id="main-content" tabindex="-1">
       <section id="intro" class="hero-section">
         <div class="shell">
-          <div class="hero-layout">
-            <div class="hero">
-              <div class="hero-grid">
-                <div class="hero-content">
-                  <span class="hero-eyebrow">PSAppDeployToolkit v4 ready</span>
-                  <h2>
-                    Ship reliable deployments without the guesswork
-                    <span aria-hidden="true">✨</span>
-                  </h2>
-                  <p class="hero-copy">
-                    Cloudcook PSADT Helper translates curated packaging scenarios
-                    into production-ready commands, pairing automation with
-                    human-friendly guidance.
-                  </p>
-                  <ul class="hero-steps">
-                    <li>
-                      <span class="emoji" aria-hidden="true">📂</span
-                      ><span>Browse curated PSADT scenarios tailored to common rollouts.</span>
-                    </li>
-                    <li>
-                      <span class="emoji" aria-hidden="true">🛠️</span
-                      ><span>Complete the smart form with the context your environment needs.</span>
-                    </li>
-                    <li>
-                      <span class="emoji" aria-hidden="true">⚡</span
-                      ><span
-                        >Queue, export, or share commands instantly—no waiting or
-                        guesswork.</span
-                      >
-                    </li>
-                  </ul>
-                  <div class="hero-actions">
-                    <a href="#scenario-search" class="btn btn-primary"
-                      >Start building</a
-                    >
-                    <a
-                      href="#builder"
-                      class="btn btn-ghost"
-                      data-open-builder
-                      >Open command builder</a
-                    >
-                  </div>
-                </div>
-                <div class="hero-visual" aria-hidden="true">
-                  <div class="hero-card">
-                    <img
-                      src="assets/cloudcook-logo.png"
-                      alt=""
-                      class="hero-logo"
-                      data-hide-on-error
-                    />
-                    <p class="hero-stat">60+ curated commands</p>
-                    <p class="hero-hint">Aligned with PSADT best practices.</p>
-                  </div>
+          <div class="hero">
+            <div class="hero-grid">
+              <div class="hero-content">
+                <span class="hero-eyebrow">PSAppDeployToolkit v4 ready</span>
+                <h2>
+                  Ship reliable deployments without the guesswork
+                  <span aria-hidden="true">✨</span>
+                </h2>
+                <p class="hero-copy">
+                  Cloudcook PSADT Helper translates curated packaging scenarios into
+                  production-ready commands, pairing automation with human-friendly
+                  guidance.
+                </p>
+                <div class="hero-actions">
+                  <a href="#scenario-search" class="btn btn-primary"
+                    >Browse scenarios</a
+                  >
+                  <a href="#builder" class="btn" data-open-builder
+                    >Command builder</a
+                  >
+                  <a href="#variable-panel" class="btn btn-ghost"
+                    >Variable helper</a
+                  >
                 </div>
               </div>
-              <div class="hero-resource resource-card" role="complementary">
-                <h3>Looking for function mappings?</h3>
-                <p>
-                  Explore every PSAppDeployToolkit v4 function and see how it maps to
-                  helper scenarios in one place.
-                </p>
-                <a
-                  class="btn btn-ghost resource-link"
-                  href="docs/reference/v4-function-mapping/"
-                >
-                  <svg class="icon" aria-hidden="true"><use href="#ic-files" /></svg>
-                  <span>Browse function mapping</span>
-                </a>
+              <div class="hero-visual" aria-hidden="true">
+                <div class="hero-card">
+                  <img
+                    src="assets/cloudcook-logo.png"
+                    alt=""
+                    class="hero-logo"
+                    data-hide-on-error
+                  />
+                  <p class="hero-stat">60+ curated commands</p>
+                  <p class="hero-hint">Aligned with PSADT best practices.</p>
+                </div>
               </div>
             </div>
-            <aside class="sidebar hero-scenarios" aria-label="Scenarios">
+          </div>
+        </div>
+      </section>
+
+      <section class="workspace" aria-label="PSADT workspace">
+        <div class="shell">
+          <div class="workspace-layout">
+            <aside class="sidebar workspace-scenarios" aria-label="Scenarios">
               <h3 class="hero-sidebar-title">Scenarios</h3>
               <input
                 type="search"
@@ -211,7 +185,111 @@
               />
               <div id="scenario-list"></div>
             </aside>
-            <aside class="tools hero-tools" aria-label="Tools">
+            <section class="content">
+              <div id="scenario-details" class="card hidden"></div>
+              <div id="output" class="card hidden">
+                <div class="output-toolbar">
+                  <span class="output-title">Generated Command</span>
+                  <div style="display: flex; gap: 8px">
+                    <button id="add-btn" class="btn">
+                      <svg class="icon"><use href="#ic-play" /></svg><span>Add</span>
+                    </button>
+                    <button id="copy-btn" class="btn">
+                      <svg class="icon"><use href="#ic-copy" /></svg><span>Copy</span>
+                    </button>
+                    <button id="share-btn" class="btn">
+                      <svg class="icon"><use href="#ic-copy" /></svg
+                      ><span>Permalink</span>
+                    </button>
+                    <button id="export-btn" class="btn">
+                      <svg class="icon"><use href="#ic-download" /></svg
+                      ><span>Export</span>
+                    </button>
+                    <button id="import-btn" class="btn">
+                      <svg class="icon"><use href="#ic-files" /></svg
+                      ><span>Import</span>
+                    </button>
+                    <input
+                      type="file"
+                      id="import-file"
+                      accept="application/json"
+                      hidden
+                    />
+                    <button id="reset-btn" class="btn"><span>Reset</span></button>
+                  </div>
+                </div>
+                <pre id="command" class="code" aria-live="polite"></pre>
+              </div>
+              <div id="script" class="card hidden">
+                <div class="output-toolbar">
+                  <span class="output-title">Script</span>
+                  <div style="display: flex; gap: 8px">
+                    <button id="share-script-btn" class="btn">
+                      <svg class="icon"><use href="#ic-copy" /></svg
+                      ><span>Copy Link</span>
+                    </button>
+                    <button id="download-script-btn" class="btn">
+                      <svg class="icon"><use href="#ic-download" /></svg
+                      ><span>Download</span>
+                    </button>
+                    <button id="copy-script-btn" class="btn">
+                      <svg class="icon"><use href="#ic-copy" /></svg
+                      ><span>Copy Script</span>
+                    </button>
+                  </div>
+                </div>
+                <div id="script-commands" aria-live="polite"></div>
+              </div>
+              <details id="builder" class="card panel" data-panel>
+                <summary class="panel-header">
+                  <div class="panel-title">
+                    <span class="panel-title-label">Command Builder</span>
+                    <span class="panel-title-hint">Compose reusable PSADT snippets</span>
+                  </div>
+                  <span class="panel-toggle" aria-hidden="true"></span>
+                </summary>
+                <div class="panel-body" data-panel-body>
+                  <div class="panel-body-content">
+                    <div class="cmd-layout">
+                      <div class="cmd-library">
+                        <label class="visually-hidden" for="command-search"
+                          >Search commands</label
+                        >
+                        <input
+                          type="search"
+                          id="command-search"
+                          class="cmd-search"
+                          placeholder="Search commands"
+                          aria-label="Search commands"
+                        />
+                        <div
+                          id="command-boxes"
+                          class="cmd-boxes"
+                          aria-label="PSADT commands"
+                        ></div>
+                      </div>
+                      <div
+                        id="command-detail"
+                        class="cmd-detail empty"
+                        aria-live="polite"
+                      >
+                        <p>Select a command to view parameters.</p>
+                      </div>
+                    </div>
+                    <div
+                      id="editor-area"
+                      class="cmd-editor"
+                      contenteditable="true"
+                      aria-label="Custom script editor"
+                    ></div>
+                  </div>
+                </div>
+              </details>
+              <div id="empty" class="empty">
+                <p>Select a scenario to begin.</p>
+              </div>
+            </section>
+            <aside class="tools workspace-tools" aria-label="Variable helper">
               <details
                 class="card panel variable-card"
                 id="variable-panel"
@@ -267,115 +345,6 @@
               </details>
             </aside>
           </div>
-        </div>
-      </section>
-
-      <section class="workspace" aria-label="PSADT workspace">
-        <div class="shell">
-          <section class="content">
-            <div id="scenario-details" class="card hidden"></div>
-            <div id="output" class="card hidden">
-              <div class="output-toolbar">
-                <span class="output-title">Generated Command</span>
-                <div style="display: flex; gap: 8px">
-                  <button id="add-btn" class="btn">
-                    <svg class="icon"><use href="#ic-play" /></svg><span>Add</span>
-                  </button>
-                  <button id="copy-btn" class="btn">
-                    <svg class="icon"><use href="#ic-copy" /></svg><span>Copy</span>
-                  </button>
-                  <button id="share-btn" class="btn">
-                    <svg class="icon"><use href="#ic-copy" /></svg
-                    ><span>Permalink</span>
-                  </button>
-                  <button id="export-btn" class="btn">
-                    <svg class="icon"><use href="#ic-download" /></svg
-                    ><span>Export</span>
-                  </button>
-                  <button id="import-btn" class="btn">
-                    <svg class="icon"><use href="#ic-files" /></svg
-                    ><span>Import</span>
-                  </button>
-                  <input
-                    type="file"
-                    id="import-file"
-                    accept="application/json"
-                    hidden
-                  />
-                  <button id="reset-btn" class="btn"><span>Reset</span></button>
-                </div>
-              </div>
-              <pre id="command" class="code" aria-live="polite"></pre>
-            </div>
-            <div id="script" class="card hidden">
-              <div class="output-toolbar">
-                <span class="output-title">Script</span>
-                <div style="display: flex; gap: 8px">
-                  <button id="share-script-btn" class="btn">
-                    <svg class="icon"><use href="#ic-copy" /></svg
-                    ><span>Copy Link</span>
-                  </button>
-                  <button id="download-script-btn" class="btn">
-                    <svg class="icon"><use href="#ic-download" /></svg
-                    ><span>Download</span>
-                  </button>
-                  <button id="copy-script-btn" class="btn">
-                    <svg class="icon"><use href="#ic-copy" /></svg
-                    ><span>Copy Script</span>
-                  </button>
-                </div>
-              </div>
-              <div id="script-commands" aria-live="polite"></div>
-            </div>
-            <details id="builder" class="card panel" data-panel>
-              <summary class="panel-header">
-                <div class="panel-title">
-                  <span class="panel-title-label">Command Builder</span>
-                  <span class="panel-title-hint">Compose reusable PSADT snippets</span>
-                </div>
-                <span class="panel-toggle" aria-hidden="true"></span>
-              </summary>
-              <div class="panel-body" data-panel-body>
-                <div class="panel-body-content">
-                  <div class="cmd-layout">
-                    <div class="cmd-library">
-                      <label class="visually-hidden" for="command-search"
-                        >Search commands</label
-                      >
-                      <input
-                        type="search"
-                        id="command-search"
-                        class="cmd-search"
-                        placeholder="Search commands"
-                        aria-label="Search commands"
-                      />
-                      <div
-                        id="command-boxes"
-                        class="cmd-boxes"
-                        aria-label="PSADT commands"
-                      ></div>
-                    </div>
-                    <div
-                      id="command-detail"
-                      class="cmd-detail empty"
-                      aria-live="polite"
-                    >
-                      <p>Select a command to view parameters.</p>
-                    </div>
-                  </div>
-                  <div
-                    id="editor-area"
-                    class="cmd-editor"
-                    contenteditable="true"
-                    aria-label="Custom script editor"
-                  ></div>
-                </div>
-              </div>
-            </details>
-            <div id="empty" class="empty">
-              <p>Select a scenario to begin.</p>
-            </div>
-          </section>
         </div>
       </section>
     </main>

--- a/styles.css
+++ b/styles.css
@@ -574,7 +574,7 @@ ul {
  */
 .hero-section {
   position: relative;
-  padding-block: clamp(var(--space-lg), 8vw, var(--space-2xl));
+  padding-block: clamp(var(--space-lg), 6vw, var(--space-2xl));
   background: linear-gradient(
     180deg,
     color-mix(in srgb, var(--color-bg-alt) 55%, transparent 45%) 0%,
@@ -606,7 +606,7 @@ ul {
   display: flex;
   flex-direction: column;
   gap: clamp(var(--space-sm), 3vw, var(--space-lg));
-  padding: clamp(var(--space-md), 4vw, var(--space-xl));
+  padding: clamp(var(--space-md), 3vw, var(--space-lg));
   border-radius: calc(var(--radius-lg) + 0.5rem);
   background: linear-gradient(150deg,
       color-mix(in srgb, var(--color-surface) 94%, var(--color-accent-soft) 6%) 0%,
@@ -643,28 +643,6 @@ ul {
   z-index: 1;
 }
 
-.hero-layout {
-  display: grid;
-  gap: clamp(var(--space-md), 4vw, var(--space-lg));
-  grid-template-areas: 'hero' 'scenarios' 'variables';
-}
-
-.hero-layout > * {
-  min-width: 0;
-}
-
-.hero-layout .hero {
-  grid-area: hero;
-}
-
-.hero-scenarios {
-  grid-area: scenarios;
-}
-
-.hero-tools {
-  grid-area: variables;
-}
-
 .hero-grid {
   display: grid;
   gap: clamp(var(--space-sm), 3vw, var(--space-md));
@@ -674,19 +652,6 @@ ul {
 @media (min-width: 900px) {
   .hero-grid {
     grid-template-columns: minmax(0, 1fr) minmax(0, 0.9fr);
-  }
-}
-
-@media (min-width: 880px) {
-  .hero-layout {
-    grid-template-columns: minmax(0, clamp(240px, 27vw, 360px)) minmax(0, 1fr)
-      minmax(0, clamp(240px, 27vw, 360px));
-    grid-template-areas: 'scenarios hero variables';
-    align-items: stretch;
-  }
-
-  .hero-layout .hero {
-    align-self: stretch;
   }
 }
 
@@ -724,13 +689,6 @@ ul {
   color: color-mix(in srgb, var(--color-muted) 82%, var(--color-text) 18%);
 }
 
-.hero-steps {
-  list-style: none;
-  padding: 0;
-  display: grid;
-  gap: var(--space-xs);
-}
-
 .hero-sidebar-title {
   margin: 0;
   font-size: var(--fs-500);
@@ -738,41 +696,15 @@ ul {
   color: var(--color-heading);
 }
 
-.hero-steps li {
-  display: grid;
-  grid-template-columns: auto 1fr;
-  gap: var(--space-sm);
-  align-items: center;
-  padding: clamp(var(--space-xs), 2vw, var(--space-sm))
-    clamp(var(--space-sm), 3vw, var(--space-md));
-  border-radius: var(--radius-md);
-  background: color-mix(in srgb, var(--color-surface) 96%, transparent 4%);
-  border: 1px solid color-mix(in srgb, var(--color-border) 78%, transparent 22%);
-  box-shadow: var(--shadow-xs);
-  transition: transform var(--transition-fast),
-    box-shadow var(--transition-base), border-color var(--transition-base);
-}
-
-.hero-steps .emoji {
-  font-size: 1.4rem;
-}
-
-@media (hover: hover) and (pointer: fine) {
-  .hero-steps li:hover {
-    transform: translateY(-2px);
-    box-shadow: var(--shadow-sm);
-    border-color: color-mix(in srgb, var(--color-accent) 28%, var(--color-border) 72%);
-  }
-}
 
 .hero-actions {
   display: flex;
   flex-wrap: wrap;
-  gap: var(--space-xs);
+  gap: clamp(var(--space-xs), 2vw, var(--space-sm));
 }
 
 .hero-actions .btn {
-  min-width: clamp(170px, 45vw, 220px);
+  min-width: clamp(170px, 40vw, 220px);
 }
 
 .hero-actions .btn-ghost {
@@ -817,32 +749,6 @@ ul {
   color: var(--color-muted);
 }
 
-.hero-resource {
-  align-self: flex-start;
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-sm);
-  background: color-mix(in srgb, var(--color-surface) 97%, transparent 3%);
-  border-radius: var(--radius-md);
-  padding: clamp(var(--space-sm), 2.5vw, var(--space-md));
-  border: 1px solid color-mix(in srgb, var(--color-border) 75%, transparent 25%);
-  box-shadow: var(--shadow-xs);
-}
-
-.hero-resource h3 {
-  font-size: var(--fs-500);
-}
-
-.hero-resource p {
-  color: var(--color-muted);
-}
-
-.resource-card {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-md);
-}
-
 @keyframes heroFloat {
   0% {
     transform: translateY(0) rotate(-1deg);
@@ -854,17 +760,39 @@ ul {
   }
 }
 
-.resource-link .icon {
-  width: 18px;
-  height: 18px;
-}
-
 /*
  * Layout
  * ------------------------------------------------------------------
  */
 .workspace {
   padding-block: clamp(var(--space-xl), 10vw, var(--space-3xl));
+}
+
+.workspace-layout {
+  display: grid;
+  gap: clamp(var(--space-lg), 6vw, var(--space-2xl));
+}
+
+@media (min-width: 900px) {
+  .workspace-layout {
+    grid-template-columns: minmax(0, clamp(220px, 28vw, 320px)) minmax(0, 1fr);
+  }
+
+  .workspace-tools {
+    grid-column: 1 / -1;
+  }
+}
+
+@media (min-width: 1280px) {
+  .workspace-layout {
+    grid-template-columns: minmax(0, clamp(240px, 24vw, 320px)) minmax(0, 1fr)
+      minmax(0, clamp(240px, 24vw, 320px));
+    align-items: start;
+  }
+
+  .workspace-tools {
+    grid-column: auto;
+  }
 }
 
 .sidebar,
@@ -1058,11 +986,7 @@ ul {
   align-self: start;
   max-height: calc(100vh - var(--header-height) - 2 * var(--space-lg));
   overflow: auto;
-  padding-right: clamp(var(--space-xs), 1.2vw, var(--space-sm));
-}
-
-.hero-tools {
-  padding-right: 0;
+  padding-right: clamp(var(--space-3xs), 1vw, var(--space-xs));
 }
 
 @media (max-width: 900px) {


### PR DESCRIPTION
## Summary
- simplify the hero markup so it focuses on quick navigation buttons instead of stacked content
- move the scenario library and variable helper into the main workspace layout
- update styles to tighten hero spacing and add a responsive workspace grid

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ccec88fbe08324a724fe9250ba5e30