### PR TITLE
Refine hero and workspace layouts

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,17 +142,17 @@
                   production-ready commands, pairing automation with human-friendly
                   guidance.
                 </p>
-                <div class="hero-actions">
-                  <a href="#scenario-search" class="btn btn-primary"
-                    >Browse scenarios</a
-                  >
-                  <a href="#builder" class="btn" data-open-builder
-                    >Command builder</a
-                  >
-                  <a href="#variable-panel" class="btn btn-ghost"
-                    >Variable helper</a
-                  >
-                </div>
+              </div>
+              <div class="hero-actions">
+                <a href="#scenario-search" class="btn btn-primary"
+                  >Browse scenarios</a
+                >
+                <a href="#builder" class="btn" data-open-builder
+                  >Command builder</a
+                >
+                <a href="#variable-panel" class="btn btn-ghost"
+                  >Variable helper</a
+                >
               </div>
               <div class="hero-visual" aria-hidden="true">
                 <div class="hero-card">
@@ -174,18 +174,7 @@
       <section class="workspace" aria-label="PSADT workspace">
         <div class="shell">
           <div class="workspace-layout">
-            <aside class="sidebar workspace-scenarios" aria-label="Scenarios">
-              <h3 class="hero-sidebar-title">Scenarios</h3>
-              <input
-                type="search"
-                id="scenario-search"
-                class="scenario-search"
-                placeholder="Search"
-                aria-label="Search scenarios"
-              />
-              <div id="scenario-list"></div>
-            </aside>
-            <section class="content">
+            <section class="workspace-main content">
               <div id="scenario-details" class="card hidden"></div>
               <div id="output" class="card hidden">
                 <div class="output-toolbar">
@@ -289,6 +278,17 @@
                 <p>Select a scenario to begin.</p>
               </div>
             </section>
+            <aside class="sidebar workspace-scenarios" aria-label="Scenarios">
+              <h3 class="hero-sidebar-title">Scenarios</h3>
+              <input
+                type="search"
+                id="scenario-search"
+                class="scenario-search"
+                placeholder="Search"
+                aria-label="Search scenarios"
+              />
+              <div id="scenario-list"></div>
+            </aside>
             <aside class="tools workspace-tools" aria-label="Variable helper">
               <details
                 class="card panel variable-card"

--- a/styles.css
+++ b/styles.css
@@ -646,12 +646,42 @@ ul {
 .hero-grid {
   display: grid;
   gap: clamp(var(--space-sm), 3vw, var(--space-md));
-  align-items: center;
+  align-items: start;
+  grid-template-columns: minmax(0, 1fr);
+  grid-template-areas:
+    "content"
+    "actions"
+    "visual";
+}
+
+.hero-content {
+  grid-area: content;
+}
+
+.hero-actions {
+  grid-area: actions;
+}
+
+.hero-visual {
+  grid-area: visual;
 }
 
 @media (min-width: 900px) {
   .hero-grid {
-    grid-template-columns: minmax(0, 1fr) minmax(0, 0.9fr);
+    grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.9fr);
+    grid-template-areas:
+      "content visual"
+      "actions visual";
+    align-items: stretch;
+  }
+
+  .hero-content,
+  .hero-actions {
+    align-self: start;
+  }
+
+  .hero-visual {
+    align-self: center;
   }
 }
 
@@ -771,15 +801,32 @@ ul {
 .workspace-layout {
   display: grid;
   gap: clamp(var(--space-lg), 6vw, var(--space-2xl));
+  grid-template-columns: minmax(0, 1fr);
+  grid-template-areas:
+    "main"
+    "scenarios"
+    "tools";
+}
+
+.workspace-main {
+  grid-area: main;
+}
+
+.workspace-scenarios {
+  grid-area: scenarios;
+}
+
+.workspace-tools {
+  grid-area: tools;
 }
 
 @media (min-width: 900px) {
   .workspace-layout {
     grid-template-columns: minmax(0, clamp(220px, 28vw, 320px)) minmax(0, 1fr);
-  }
-
-  .workspace-tools {
-    grid-column: 1 / -1;
+    grid-template-areas:
+      "scenarios main"
+      "tools main";
+    align-items: start;
   }
 }
 
@@ -787,11 +834,7 @@ ul {
   .workspace-layout {
     grid-template-columns: minmax(0, clamp(240px, 24vw, 320px)) minmax(0, 1fr)
       minmax(0, clamp(240px, 24vw, 320px));
-    align-items: start;
-  }
-
-  .workspace-tools {
-    grid-column: auto;
+    grid-template-areas: "scenarios main tools";
   }
 }
 


### PR DESCRIPTION
## Summary
- restructure the hero markup so the calls to action have their own row and the visual card has more room to breathe
- reorder the workspace section markup to prioritize the main command area and stack supporting panels responsively
- update the hero and workspace grid styles to assign explicit areas and improve spacing across breakpoints

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ccf31fbe0c832488c538e29903720e